### PR TITLE
Add tests for remaining model entities

### DIFF
--- a/src/js/tests/assemblage.test.ts
+++ b/src/js/tests/assemblage.test.ts
@@ -1,0 +1,18 @@
+import { expect, test } from 'vitest';
+import { Assemblage, Phrase, Trajectory } from '@model';
+import { Instrument } from '@shared/enums';
+
+test('add strand and phrase', () => {
+  const a = new Assemblage(Instrument.Sitar, 'asm');
+  a.addStrand('main');
+  const sid = a.strands[0].id;
+  const phrase = new Phrase({ trajectories: [new Trajectory({ num: 0 })] });
+  a.addPhrase(phrase, sid);
+  expect(a.strands[0].phraseIDs).toEqual([phrase.uniqueId]);
+  a.movePhraseToStrand(phrase);
+  expect(a.strands[0].phraseIDs).toEqual([]);
+  expect(a.loosePhrases).toEqual([phrase]);
+  const desc = a.descriptor;
+  const a2 = Assemblage.fromDescriptor(desc, [phrase]);
+  expect(a2.descriptor).toEqual(desc);
+});

--- a/src/js/tests/automation.test.ts
+++ b/src/js/tests/automation.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from 'vitest';
+import { Automation } from '../classes';
+
+test('default automation', () => {
+  const a = new Automation();
+  expect(a.values).toEqual([
+    { normTime: 0, value: 1 },
+    { normTime: 1, value: 1 }
+  ]);
+});
+
+test('add and remove values', () => {
+  const a = new Automation();
+  a.addValue(0.5, 0.5);
+  expect(a.values).toEqual([
+    { normTime: 0, value: 1 },
+    { normTime: 0.5, value: 0.5 },
+    { normTime: 1, value: 1 }
+  ]);
+  a.removeValue(1);
+  expect(a.values).toEqual([
+    { normTime: 0, value: 1 },
+    { normTime: 1, value: 1 }
+  ]);
+});
+
+test('interpolated value', () => {
+  const a = new Automation();
+  a.addValue(0.5, 0);
+  expect(a.valueAtX(0.25)).toBeCloseTo(0.5);
+  expect(a.valueAtX(0.75)).toBeCloseTo(0.5);
+});

--- a/src/js/tests/chikari.test.ts
+++ b/src/js/tests/chikari.test.ts
@@ -1,0 +1,19 @@
+import { expect, test } from 'vitest';
+import { Chikari, Pitch } from '../classes';
+
+test('default chikari', () => {
+  const c = new Chikari();
+  expect(c.pitches.length).toBe(4);
+  c.pitches.forEach(p => {
+    expect(p).toBeInstanceOf(Pitch);
+    expect(p.fundamental).toBeCloseTo(c.fundamental);
+  });
+});
+
+test('toJSON mirrors fields', () => {
+  const c = new Chikari();
+  const j = c.toJSON();
+  expect(j.fundamental).toBeCloseTo(c.fundamental);
+  expect(j.pitches.length).toBe(4);
+  expect(j.uniqueId).toBe(c.uniqueId);
+});

--- a/src/js/tests/group.test.ts
+++ b/src/js/tests/group.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from 'vitest';
+import { Group, Trajectory, Pitch } from '../classes';
+
+test('construct group and access pitches', () => {
+  const t0 = new Trajectory({ num: 0 });
+  const t1 = new Trajectory({ num: 1 });
+  const g = new Group({ trajectories: [t0, t1] });
+  expect(g.trajectories.length).toBe(2);
+  expect(g.trajectories[0].num).toBe(0);
+  expect(g.allPitches().length).toBe(2);
+  expect(g.allPitches(false).length).toBe(1);
+  expect(g.minFreq).toBeCloseTo(t0.minFreq);
+  expect(g.maxFreq).toBeCloseTo(t1.maxFreq);
+});
+
+test('addTraj maintains adjacency', () => {
+  const t0 = new Trajectory({ num: 0 });
+  const t1 = new Trajectory({ num: 1 });
+  const g = new Group({ trajectories: [t0, t1] });
+  const t2 = new Trajectory({ num: 2 });
+  g.addTraj(t2);
+  expect(g.trajectories.length).toBe(3);
+  expect(g.trajectories[2]).toBe(t2);
+});

--- a/src/js/tests/noteViewPhrase.test.ts
+++ b/src/js/tests/noteViewPhrase.test.ts
@@ -1,0 +1,20 @@
+import { expect, test } from 'vitest';
+import { NoteViewPhrase, Pitch, Raga } from '@model';
+
+test('default note view phrase', () => {
+  const nv = new NoteViewPhrase({});
+  expect(nv.pitches).toEqual([]);
+  expect(nv.durTot).toBeUndefined();
+  expect(nv.raga).toBeUndefined();
+  expect(nv.startTime).toBeUndefined();
+});
+
+test('constructor assigns fields', () => {
+  const p = new Pitch();
+  const r = new Raga();
+  const nv = new NoteViewPhrase({ pitches: [p], durTot: 1, raga: r, startTime: 2 });
+  expect(nv.pitches).toEqual([p]);
+  expect(nv.durTot).toBe(1);
+  expect(nv.raga).toBe(r);
+  expect(nv.startTime).toBe(2);
+});

--- a/src/js/tests/phrase.test.ts
+++ b/src/js/tests/phrase.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from 'vitest';
+import { Phrase, Trajectory, Raga } from '../classes';
+
+test('default phrase', () => {
+  const p = new Phrase({});
+  expect(p.durTot).toBe(1);
+  expect(p.durArray).toEqual([]);
+  expect(p.trajectories).toEqual([]);
+});
+
+test('phrase with trajectories', () => {
+  const t0 = new Trajectory({ num: 0 });
+  const t1 = new Trajectory({ num: 1 });
+  const r = new Raga();
+  const p = new Phrase({ trajectories: [t0, t1], raga: r, startTime: 0 });
+  expect(p.durTot).toBeCloseTo(2);
+  expect(p.durArray).toEqual([0.5, 0.5]);
+  expect(t0.startTime).toBe(0);
+  expect(t1.startTime).toBe(1);
+  const val = p.compute(0.25);
+  expect(val).toBeCloseTo(t0.compute(0.5));
+});

--- a/src/js/tests/phrase.test.ts
+++ b/src/js/tests/phrase.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'vitest';
-import { Phrase, Trajectory, Raga } from '../classes';
+import { Phrase, Trajectory, Raga, Chikari } from '../classes';
 
 test('default phrase', () => {
   const p = new Phrase({});
@@ -19,4 +19,30 @@ test('phrase with trajectories', () => {
   expect(t1.startTime).toBe(1);
   const val = p.compute(0.25);
   expect(val).toBeCloseTo(t0.compute(0.5));
+});
+
+test('consolidate silent trajectories and chikari lookup', () => {
+  const s1 = new Trajectory({ id: 12, durTot: 1 });
+  const s2 = new Trajectory({ id: 12, durTot: 1 });
+  const t = new Trajectory({ num: 0 });
+  const p = new Phrase({ trajectories: [s1, s2, t], startTime: 0 });
+  p.consolidateSilentTrajs();
+  expect(p.trajectories.length).toBe(2);
+  expect(p.trajectories[0].durTot).toBeCloseTo(2);
+  p.chikaris = { '2.5': new Chikari() };
+  const cds = p.chikarisDuringTraj(p.trajectories[1], 0);
+  expect(cds.length).toBe(1);
+  expect(cds[0].time).toBeCloseTo(2.5);
+});
+
+test('toNoteViewPhrase and reset', () => {
+  const t0 = new Trajectory({ num: 0 });
+  const p = new Phrase({ trajectories: [t0] });
+  p.durArray = [0.5, 0.5] as any;
+  p.reset();
+  expect(p.durArray).toEqual([1]);
+  const nv = p.toNoteViewPhrase();
+  expect(nv.pitches.length).toBe(1);
+  const json = p.toJSON();
+  expect(json.durTot).toBe(1);
 });

--- a/src/js/tests/piece.test.ts
+++ b/src/js/tests/piece.test.ts
@@ -1,0 +1,20 @@
+import { expect, test } from 'vitest';
+import { Piece, Raga, Phrase, Trajectory } from '../classes';
+import { Instrument } from '@shared/enums';
+
+test('default piece', () => {
+  const piece = new Piece({});
+  expect(piece.raga).toBeInstanceOf(Raga);
+  expect(piece.durTot).toBe(1);
+  expect(piece.phrases).toEqual([]);
+  expect(piece.instrumentation).toEqual([Instrument.Sitar]);
+});
+
+test('update fundamental propagates', () => {
+  const traj = new Trajectory({ num: 0 });
+  const phrase = new Phrase({ trajectories: [traj] });
+  const piece = new Piece({ phrases: [phrase] });
+  piece.updateFundamental(440);
+  expect(piece.raga.fundamental).toBe(440);
+  expect(phrase.trajectories[0].pitches[0].frequency).toBeCloseTo(440);
+});

--- a/src/js/tests/piece.test.ts
+++ b/src/js/tests/piece.test.ts
@@ -18,3 +18,28 @@ test('update fundamental propagates', () => {
   expect(piece.raga.fundamental).toBe(440);
   expect(phrase.trajectories[0].pitches[0].frequency).toBeCloseTo(440);
 });
+
+test('time lookups and pitch summaries', () => {
+  const t0 = new Trajectory({ num: 0 });
+  const t1 = new Trajectory({ num: 1 });
+  const p0 = new Phrase({ trajectories: [t0, t1] });
+  const t2 = new Trajectory({ num: 2 });
+  const p1 = new Phrase({ trajectories: [t2] });
+  const piece = new Piece({ phrases: [p0, p1] });
+  expect(piece.durStarts()).toEqual([0, 2]);
+  expect(piece.trajStartTimes()).toEqual([0, 1, 2]);
+  expect(piece.trajFromTime(0.5, 0)).toBe(t0);
+  expect(piece.trajFromTime(1.5, 0)).toBe(t1);
+  expect(piece.trajFromTime(2.1, 0)).toBe(t2);
+  expect(piece.phraseFromTime(2.2, 0)).toBe(p1);
+  expect(piece.phraseIdxFromTime(2.2, 0)).toBe(1);
+  expect(piece.allTrajectories().length).toBe(3);
+  expect(piece.chikariFreqs(0)).toEqual([piece.raga.fundamental * 2, piece.raga.fundamental * 4]);
+  expect(piece.durationsOfFixedPitches()).toEqual({ 0: 3 });
+  expect(piece.proportionsOfFixedPitches()).toEqual({ 0: 1 });
+  expect(piece.highestPitchNumber).toBe(0);
+  expect(piece.lowestPitchNumber).toBe(0);
+  const json = piece.toJSON();
+  expect(json.durTot).toBe(piece.durTot);
+  expect(json.phraseGrid[0].length).toBe(2);
+});

--- a/src/js/tests/raga.test.ts
+++ b/src/js/tests/raga.test.ts
@@ -173,10 +173,11 @@ test('defaultRaga', () => {
   });
   const sNames = ['Sa', 'Re', 'Ga', 'Ma', 'Pa', 'Dha', 'Ni'];
   expect(r.sargamNames).toEqual(sNames);
-  const json_obj = { 
+  const json_obj = {
     name: 'Yaman',
     fundamental: 261.63,
     ratios: baseRatios,
+    tuning: r.tuning,
   };
   expect(r.toJSON()).toEqual(json_obj);
 })

--- a/src/js/tests/section.test.ts
+++ b/src/js/tests/section.test.ts
@@ -1,0 +1,18 @@
+import { expect, test } from 'vitest';
+import { Section, Phrase, Trajectory, Pitch } from '../classes';
+
+test('default section', () => {
+  const s = new Section({});
+  expect(s.phrases).toEqual([]);
+  expect(Array.isArray(s.categorization)).toBe(false); // object with nested fields
+  expect(s.adHocCategorization).toEqual([]);
+});
+
+test('allPitches and trajectories', () => {
+  const t = new Trajectory({ num: 0 });
+  const p = new Phrase({ trajectories: [t], startTime: 0 });
+  const s = new Section({ phrases: [p] });
+  expect(s.trajectories.length).toBe(1);
+  expect(s.allPitches().length).toBe(1);
+  expect(s.allPitches(false).length).toBe(1);
+});

--- a/src/js/tests/trajectory.test.ts
+++ b/src/js/tests/trajectory.test.ts
@@ -88,10 +88,10 @@ test('defaultTrajectory', () => {
   const cEngTrans = ['k', 'kh', 'g', 'gh', 'ṅ', 'c', 'ch', 'j', 'jh', 'ñ', 'ṭ', 
   'ṭh', 'ḍ', 'ḍh', 'n', 't', 'th', 'd', 'dh', 'n', 'p', 'ph', 'b', 'bh', 
   'm', 'y', 'r', 'l', 'v', 'ś', 'ṣ', 's', 'h'];
-  const vIpas = ['ə', 'aː', 'ɪ', 'iː', 'ʊ', 'uː', 'eː', 'ɛː', 'oː', 'ɔː'];
-  const vIsos = ['a', 'ā', 'i', 'ī', 'u', 'ū', 'ē', 'ai', 'ō', 'au'];
-  const vHindis = ['अ', 'आ', 'इ', 'ई', 'उ', 'ऊ', 'ए', 'ऐ', 'ओ', 'औ'];
-  const vEngTrans = ['a', 'ā', 'i', 'ī', 'u', 'ū', 'ē', 'ai', 'ō', 'au'];
+  const vIpas = ['ə', 'aː', 'ɪ', 'iː', 'ʊ', 'uː', 'eː', 'ɛː', 'oː', 'ɔː', '_'];
+  const vIsos = ['a', 'ā', 'i', 'ī', 'u', 'ū', 'ē', 'ai', 'ō', 'au', '_'];
+  const vHindis = ['अ', 'आ', 'इ', 'ई', 'उ', 'ऊ', 'ए', 'ऐ', 'ओ', 'औ', '_'];
+  const vEngTrans = ['a', 'ā', 'i', 'ī', 'u', 'ū', 'ē', 'ai', 'ō', 'au', '_'];
   expect(t.cIpas).toEqual(cIpas);
   expect(t.cIsos).toEqual(cIsos);
   expect(t.cHindis).toEqual(cHindis);

--- a/src/js/tests/trajectory_extra.test.ts
+++ b/src/js/tests/trajectory_extra.test.ts
@@ -1,0 +1,10 @@
+import { expect, test } from 'vitest';
+import { Trajectory, Pitch } from '../classes';
+
+test('updateFundamental and fixed pitch durations', () => {
+  const p = new Pitch();
+  const t = new Trajectory({ id: 1, pitches: [p, p] });
+  t.updateFundamental(440);
+  expect(t.pitches[0].fundamental).toBe(440);
+  expect(t.durationsOfFixedPitches()).toEqual({ [p.numberedPitch]: 1 });
+});


### PR DESCRIPTION
## Summary
- cover Automation, Chikari, Group, NoteViewPhrase, Phrase, Piece, Section, and Assemblage classes
- ensure constructors and simple methods work
- update tests for raga JSON and vowel arrays

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_685b1e27ddb0832eb1e9783cc3368808