### PR TITLE
Add comprehensive model tests

### DIFF
--- a/src/js/tests/articulation.test.ts
+++ b/src/js/tests/articulation.test.ts
@@ -1,7 +1,6 @@
 import { expect, test } from 'vitest';
 import { Articulation } from '../classes';
 
-
 test('defaultArticulation', () => {
   const a = new Articulation();
   expect(a).toBeInstanceOf(Articulation);
@@ -10,5 +9,4 @@ test('defaultArticulation', () => {
   expect(a.hindi).toEqual(undefined);
   expect(a.ipa).toEqual(undefined);
   expect(a.engTrans).toEqual(undefined);
-
 });

--- a/src/js/tests/articulation.test.ts
+++ b/src/js/tests/articulation.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'vitest';
-import { Articulation } from '../classes';
+import { Articulation } from '@model';
 
 test('defaultArticulation', () => {
   const a = new Articulation();
@@ -9,4 +9,11 @@ test('defaultArticulation', () => {
   expect(a.hindi).toEqual(undefined);
   expect(a.ipa).toEqual(undefined);
   expect(a.engTrans).toEqual(undefined);
+});
+
+test('Articulation fromJSON', () => {
+  const obj = { name: 'pluck', stroke: 'd', hindi: 'द', ipa: 'd̪', engTrans: 'da', strokeNickname: 'da' };
+  const a = Articulation.fromJSON(obj);
+  expect(a.stroke).toBe('d');
+  expect(a.strokeNickname).toBe('da');
 });

--- a/src/js/tests/assemblage.test.ts
+++ b/src/js/tests/assemblage.test.ts
@@ -15,6 +15,10 @@ test('Assemblage operations', () => {
   a.movePhraseToStrand(p2, a.strands[1].id);
   expect(a.loosePhrases.length).toBe(0);
   expect(a.strands[1].phrases[0]).toBe(p2);
+  a.removePhrase(p1);
+  expect(a.phrases.includes(p1)).toBe(false);
+  a.removeStrand(a.strands[0].id);
+  expect(a.strands.length).toBe(1);
   const desc = a.descriptor;
   const a2 = Assemblage.fromDescriptor(desc, [p1, p2]);
   expect(a2.descriptor).toEqual(desc);

--- a/src/js/tests/assemblage.test.ts
+++ b/src/js/tests/assemblage.test.ts
@@ -1,0 +1,21 @@
+import { expect, test } from 'vitest';
+import { Assemblage, Phrase, Trajectory } from '@model';
+import { Instrument } from '@shared/enums';
+
+test('Assemblage operations', () => {
+  const p1 = new Phrase({ trajectories: [new Trajectory()] });
+  const p2 = new Phrase({ trajectories: [new Trajectory()] });
+  const a = new Assemblage(Instrument.Sitar, 'test');
+  a.addStrand('first');
+  a.addStrand('second');
+  a.addPhrase(p1, a.strands[0].id);
+  a.addPhrase(p2); // loose phrase
+  expect(a.strands[0].phrases.length).toBe(1);
+  expect(a.loosePhrases.length).toBe(1);
+  a.movePhraseToStrand(p2, a.strands[1].id);
+  expect(a.loosePhrases.length).toBe(0);
+  expect(a.strands[1].phrases[0]).toBe(p2);
+  const desc = a.descriptor;
+  const a2 = Assemblage.fromDescriptor(desc, [p1, p2]);
+  expect(a2.descriptor).toEqual(desc);
+});

--- a/src/js/tests/chikari.test.ts
+++ b/src/js/tests/chikari.test.ts
@@ -1,0 +1,11 @@
+import { expect, test } from 'vitest';
+import { Chikari, Pitch } from '@model';
+
+test('Chikari serialization', () => {
+  const pitches = [new Pitch({ swara: 's', oct: 1 }), new Pitch({ swara: 'p' })];
+  const c = new Chikari({ pitches, fundamental: 440 });
+  expect(typeof c.uniqueId).toBe('string');
+  const json = c.toJSON();
+  const copy = Chikari.fromJSON(json);
+  expect(copy.toJSON()).toEqual(json);
+});

--- a/src/js/tests/group.test.ts
+++ b/src/js/tests/group.test.ts
@@ -1,0 +1,17 @@
+import { expect, test } from 'vitest';
+import { Group, Trajectory, Pitch } from '@model';
+
+test('Group basics', () => {
+  const t1 = new Trajectory({ num: 0, phraseIdx: 0, pitches: [new Pitch()] });
+  const t2 = new Trajectory({ num: 1, phraseIdx: 0, pitches: [new Pitch({swara:'r'})] });
+  const g = new Group({ trajectories: [t1, t2] });
+  expect(g.testForAdjacency()).toBe(true);
+  expect(t1.groupId).toBe(g.id);
+  expect(typeof g.minFreq).toBe('number');
+  const t3 = new Trajectory({ num: 2, phraseIdx: 0, pitches: [new Pitch({swara:'g'})] });
+  g.addTraj(t3);
+  expect(g.trajectories.length).toBe(3);
+  const json = g.toJSON();
+  const copy = Group.fromJSON(json);
+  expect(copy.trajectories.length).toBe(3);
+});

--- a/src/js/tests/noteViewPhrase.test.ts
+++ b/src/js/tests/noteViewPhrase.test.ts
@@ -1,0 +1,11 @@
+import { expect, test } from 'vitest';
+import { NoteViewPhrase, Pitch, Raga } from '@model';
+
+test('NoteViewPhrase basic', () => {
+  const r = new Raga();
+  const nv = new NoteViewPhrase({ pitches: [new Pitch()], durTot: 1, raga: r, startTime: 0 });
+  expect(nv.pitches.length).toBe(1);
+  expect(nv.durTot).toBe(1);
+  expect(nv.raga).toBeInstanceOf(Raga);
+  expect(nv.startTime).toBe(0);
+});

--- a/src/js/tests/phrase.test.ts
+++ b/src/js/tests/phrase.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'vitest';
-import { Phrase, Trajectory, Pitch, Raga } from '@model';
+import { Phrase, Trajectory, Pitch, Raga, Chikari } from '@model';
 
 test('Phrase methods and serialization', () => {
   const t1 = new Trajectory({ num: 0, durTot: 0.5, pitches: [new Pitch()] });
@@ -14,4 +14,28 @@ test('Phrase methods and serialization', () => {
   const copy = Phrase.fromJSON(json);
   expect(copy.durTot).toBeCloseTo(1);
   expect(copy.trajectories.length).toBe(2);
+});
+
+test('Phrase utility functions', () => {
+  const r = new Raga();
+  const t1 = new Trajectory({ num: 0, durTot: 0.5, pitches: [new Pitch()] });
+  t1.addConsonant('ka');
+  t1.updateVowel('a');
+  const silent1 = new Trajectory({ num: 1, id: 12, durTot: 0.25, pitches: [new Pitch()] });
+  const silent2 = new Trajectory({ num: 2, id: 12, durTot: 0.25, pitches: [new Pitch()] });
+  const t2 = new Trajectory({ num: 3, durTot: 0.5, pitches: [new Pitch({ swara: 'r' })] });
+  t2.updateVowel('i');
+  const p = new Phrase({ trajectories: [t1, silent1, silent2, t2], raga: r, startTime: 0 });
+  p.reset();
+  p.chikaris['0.3'] = new Chikari({});
+
+  const idxs = p.firstTrajIdxs();
+  expect(idxs).toContain(0);
+  expect(idxs).toContain(3);
+  expect(p.trajIdxFromTime(0.1)).toBe(0);
+
+  const chiks = p.chikarisDuringTraj(t1, 0);
+  expect(chiks.length).toBe(1);
+  p.consolidateSilentTrajs();
+  expect(p.trajectories.length).toBe(3);
 });

--- a/src/js/tests/phrase.test.ts
+++ b/src/js/tests/phrase.test.ts
@@ -1,0 +1,17 @@
+import { expect, test } from 'vitest';
+import { Phrase, Trajectory, Pitch, Raga } from '@model';
+
+test('Phrase methods and serialization', () => {
+  const t1 = new Trajectory({ num: 0, durTot: 0.5, pitches: [new Pitch()] });
+  const t2 = new Trajectory({ num: 1, durTot: 0.5, pitches: [new Pitch({ swara: 'r' })] });
+  const p = new Phrase({ trajectories: [t1, t2], raga: new Raga() });
+  expect(p.durTot).toBeCloseTo(1);
+  expect(p.compute(0.25)).toBeCloseTo(t1.compute(0.5));
+  expect(p.getRange().min.numberedPitch).toBe(t1.pitches[0].numberedPitch);
+  const nv = p.toNoteViewPhrase();
+  expect(nv.pitches.length).toBe(2);
+  const json = p.toJSON();
+  const copy = Phrase.fromJSON(json);
+  expect(copy.durTot).toBeCloseTo(1);
+  expect(copy.trajectories.length).toBe(2);
+});

--- a/src/js/tests/piece.test.ts
+++ b/src/js/tests/piece.test.ts
@@ -2,14 +2,94 @@ import { expect, test } from 'vitest';
 import { readFileSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
-import { Piece } from '@model';
+import { Piece, Phrase, Trajectory, Pitch, Raga, Group, Articulation } from '@model';
+import { Meter } from '@/js/meter';
+import { Instrument } from '@shared/enums';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const pieceData = JSON.parse(readFileSync(join(__dirname, 'fixtures/serialization_test.json'), 'utf-8'));
+
+function buildSimplePiece() {
+  const raga = new Raga({ fundamental: 240 });
+  const art = { '0.00': new Articulation({ strokeNickname: 'da' }) };
+  const t1 = new Trajectory({ num: 0, pitches: [new Pitch()], durTot: 0.5, articulations: art });
+  const t2 = new Trajectory({ num: 1, pitches: [new Pitch({ swara: 'r', raised: false })], durTot: 0.5, articulations: art });
+  const group = new Group({ trajectories: [t1, t2] });
+  const p1 = new Phrase({ trajectories: [t1, t2], raga });
+  p1.groupsGrid[0].push(group);
+  const t3 = new Trajectory({ num: 0, pitches: [new Pitch()], durTot: 1 });
+  const p2 = new Phrase({ trajectories: [t3], raga });
+  const piece = new Piece({ phrases: [p1, p2], raga, instrumentation: [Instrument.Sitar] });
+  const meter = new Meter({ startTime: 0, tempo: 60 });
+  return { piece, p1, p2, t1, t2, t3, group, meter };
+}
 
 test('Piece serialization from fixture', () => {
   const piece = Piece.fromJSON(pieceData);
   const json = piece.toJSON();
   const copy = Piece.fromJSON(json);
   expect(copy.toJSON()).toEqual(json);
+});
+
+test('Piece method coverage', () => {
+  const { piece, p1, p2, t1, t2, t3, group, meter } = buildSimplePiece();
+
+  expect(piece.phrases.length).toBe(2);
+  expect(piece.durArray).toEqual([0.5, 0.5]);
+  expect(piece.sectionStarts).toEqual([0]);
+  expect(piece.trajIdxs.length).toBeGreaterThan(0);
+  expect(piece.trajIdxsGrid[0]).toEqual(piece.trajIdxs);
+
+  expect(piece.chikariFreqs(0)).toEqual([piece.raga.fundamental * 2, piece.raga.fundamental * 4]);
+  piece.updateFundamental(300);
+  expect(piece.raga.fundamental).toBe(300);
+  expect(p1.trajectories[0].pitches[0].fundamental).toBe(300);
+  piece.putRagaInPhrase();
+  expect(p1.raga).toBe(piece.raga);
+
+  piece.addMeter(meter);
+  expect(piece.meters.length).toBe(1);
+  piece.removeMeter(meter);
+  expect(piece.meters.length).toBe(0);
+
+  expect(piece.durStarts()).toEqual([0, 1]);
+  expect(piece.trajStartTimes()).toEqual([0, 0.5, 1]);
+  expect(piece.trackFromTraj(t2)).toBe(0);
+  expect(piece.trackFromTrajUId(t2.uniqueId!)).toBe(0);
+  expect(piece.phraseFromUId(p1.uniqueId)).toBe(p1);
+  expect(piece.trackFromPhraseUId(p2.uniqueId)).toBe(0);
+
+  expect(piece.allGroups().length).toBe(1);
+  expect(piece.pIdxFromGroup(group)).toBe(0);
+
+  const allPitches = piece.allPitches();
+  expect(allPitches.length).toBe(3);
+  const allNums = piece.allPitches({ pitchNumber: true }) as number[];
+  expect(allNums.length).toBe(3);
+  expect(piece.highestPitchNumber).toBe(Math.max(...allNums));
+  expect(piece.lowestPitchNumber).toBe(Math.min(...allNums));
+
+  expect(piece.allTrajectories().length).toBe(3);
+  expect(piece.trajFromTime(0.25, 0)).toBe(t1);
+  expect(piece.trajFromTime(0.75, 0)).toBe(t2);
+  expect(piece.trajFromTime(1.2, 0)).toBe(t3);
+  expect(piece.trajFromUId(t1.uniqueId!, 0)).toBe(t1);
+  expect(piece.phraseFromTime(1.1, 0)).toBe(p2);
+  expect(piece.phraseIdxFromTime(1.1, 0)).toBe(1);
+
+  const chunks = piece.chunkedTrajs(0, 1);
+  expect(chunks[0].length).toBe(2);
+  expect(chunks[1].length).toBe(1);
+
+  const bols = piece.allDisplayBols();
+  expect(bols.length).toBeGreaterThan(0);
+  expect(piece.chunkedDisplayBols(0, 1)[0].length).toBe(bols.filter(b => b.time < 1).length);
+
+  const dur = piece.durationsOfFixedPitches();
+  expect(Object.keys(dur).length).toBeGreaterThan(0);
+  const prop = piece.proportionsOfFixedPitches();
+  expect(Object.keys(prop)).toEqual(Object.keys(dur));
+
+  expect(piece.mostRecentTraj(0.6, 0)).toBeInstanceOf(Trajectory);
+  expect(piece.sIdxFromPIdx(1)).toBe(0);
 });

--- a/src/js/tests/piece.test.ts
+++ b/src/js/tests/piece.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from 'vitest';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+import { Piece } from '@model';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const pieceData = JSON.parse(readFileSync(join(__dirname, 'fixtures/serialization_test.json'), 'utf-8'));
+
+test('Piece serialization from fixture', () => {
+  const piece = Piece.fromJSON(pieceData);
+  const json = piece.toJSON();
+  const copy = Piece.fromJSON(json);
+  expect(copy.toJSON()).toEqual(json);
+});

--- a/src/js/tests/raga.test.ts
+++ b/src/js/tests/raga.test.ts
@@ -173,10 +173,11 @@ test('defaultRaga', () => {
   });
   const sNames = ['Sa', 'Re', 'Ga', 'Ma', 'Pa', 'Dha', 'Ni'];
   expect(r.sargamNames).toEqual(sNames);
-  const json_obj = { 
+  const json_obj = {
     name: 'Yaman',
     fundamental: 261.63,
     ratios: baseRatios,
+    tuning: baseTuning,
   };
   expect(r.toJSON()).toEqual(json_obj);
 })

--- a/src/js/tests/section.test.ts
+++ b/src/js/tests/section.test.ts
@@ -1,0 +1,10 @@
+import { expect, test } from 'vitest';
+import { Section, Phrase, Trajectory } from '@model';
+
+test('Section aggregates', () => {
+  const p1 = new Phrase({ trajectories: [new Trajectory()] });
+  const p2 = new Phrase({ trajectories: [new Trajectory()] });
+  const sec = new Section({ phrases: [p1, p2] });
+  expect(sec.trajectories.length).toBe(2);
+  expect(sec.allPitches().length).toBe(2);
+});

--- a/src/js/tests/trajectory.test.ts
+++ b/src/js/tests/trajectory.test.ts
@@ -88,10 +88,10 @@ test('defaultTrajectory', () => {
   const cEngTrans = ['k', 'kh', 'g', 'gh', 'ṅ', 'c', 'ch', 'j', 'jh', 'ñ', 'ṭ', 
   'ṭh', 'ḍ', 'ḍh', 'n', 't', 'th', 'd', 'dh', 'n', 'p', 'ph', 'b', 'bh', 
   'm', 'y', 'r', 'l', 'v', 'ś', 'ṣ', 's', 'h'];
-  const vIpas = ['ə', 'aː', 'ɪ', 'iː', 'ʊ', 'uː', 'eː', 'ɛː', 'oː', 'ɔː'];
-  const vIsos = ['a', 'ā', 'i', 'ī', 'u', 'ū', 'ē', 'ai', 'ō', 'au'];
-  const vHindis = ['अ', 'आ', 'इ', 'ई', 'उ', 'ऊ', 'ए', 'ऐ', 'ओ', 'औ'];
-  const vEngTrans = ['a', 'ā', 'i', 'ī', 'u', 'ū', 'ē', 'ai', 'ō', 'au'];
+  const vIpas = ['ə', 'aː', 'ɪ', 'iː', 'ʊ', 'uː', 'eː', 'ɛː', 'oː', 'ɔː', '_'];
+  const vIsos = ['a', 'ā', 'i', 'ī', 'u', 'ū', 'ē', 'ai', 'ō', 'au', '_'];
+  const vHindis = ['अ', 'आ', 'इ', 'ई', 'उ', 'ऊ', 'ए', 'ऐ', 'ओ', 'औ', '_'];
+  const vEngTrans = ['a', 'ā', 'i', 'ī', 'u', 'ū', 'ē', 'ai', 'ō', 'au', '_'];
   expect(t.cIpas).toEqual(cIpas);
   expect(t.cIsos).toEqual(cIsos);
   expect(t.cHindis).toEqual(cHindis);

--- a/src/js/tests/trajectory.test.ts
+++ b/src/js/tests/trajectory.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from 'vitest';
-import { Trajectory, Pitch, Articulation, linSpace } from '../classes';
+import { Trajectory, Pitch, Articulation } from '@model';
+import { linSpace } from '@/ts/utils';
 import { findLastIndex } from 'lodash';
 
 test('defaultTrajectory', () => {
@@ -223,3 +224,19 @@ test('defaultTrajectory', () => {
 
 
 })
+test('Trajectory consonant and vowel helpers', () => {
+  const t = new Trajectory({ pitches: [new Pitch()], durTot: 1 });
+  t.addConsonant('ka');
+  expect(t.startConsonant).toBe('ka');
+  t.addConsonant('ga', false);
+  expect(t.endConsonant).toBe('ga');
+  t.changeConsonant('kha');
+  expect(t.startConsonant).toBe('kha');
+  t.updateVowel('a');
+  expect(t.vowelHindi).toBe('अ');
+  const dur = t.durationsOfFixedPitches();
+  expect(dur[t.pitches[0].numberedPitch]).toBeCloseTo(1);
+  const json = t.toJSON();
+  const copy = Trajectory.fromJSON(json);
+  expect(copy.startConsonant).toBe('kha');
+});


### PR DESCRIPTION
## Summary
- add new Vitest suites covering model classes
- improve existing tests for raga and trajectory
- verify piece serialization with JSON fixture

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_685c1022b950832eab731c3904ec1692