### PR TITLE
Add trajectory round-trip and compute tests

### DIFF
--- a/src/js/tests/raga.test.ts
+++ b/src/js/tests/raga.test.ts
@@ -173,10 +173,11 @@ test('defaultRaga', () => {
   });
   const sNames = ['Sa', 'Re', 'Ga', 'Ma', 'Pa', 'Dha', 'Ni'];
   expect(r.sargamNames).toEqual(sNames);
-  const json_obj = { 
+  const json_obj = {
     name: 'Yaman',
     fundamental: 261.63,
     ratios: baseRatios,
+    tuning: r.tuning,
   };
   expect(r.toJSON()).toEqual(json_obj);
 })


### PR DESCRIPTION
## Summary
- extend `trajectory.test.ts` to cover toJSON/fromJSON round trips
- verify compute for id7–id13
- ensure consonant and vowel helpers handle invalid input
- update tests to match underscore entries and tuning field

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_685dc094fb1c832eb2c08bbcc9ae3283