### PR TITLE
Add Section aggregation tests

### DIFF
--- a/src/js/tests/section.test.ts
+++ b/src/js/tests/section.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'vitest';
-import { Section, Phrase, Trajectory } from '@model';
+import { Section, Phrase, Trajectory, Pitch } from '@model';
 
 test('Section aggregates', () => {
   const p1 = new Phrase({ trajectories: [new Trajectory()] });
@@ -7,4 +7,17 @@ test('Section aggregates', () => {
   const sec = new Section({ phrases: [p1, p2] });
   expect(sec.trajectories.length).toBe(2);
   expect(sec.allPitches().length).toBe(2);
+});
+
+test('Section allPitches and trajectories getters', () => {
+  const sa1 = new Trajectory({ pitches: [new Pitch({ swara: 'sa' })] });
+  const sa2 = new Trajectory({ pitches: [new Pitch({ swara: 'sa' })] });
+  const re = new Trajectory({ pitches: [new Pitch({ swara: 're' })] });
+
+  const p1 = new Phrase({ trajectories: [sa1, sa2] });
+  const p2 = new Phrase({ trajectories: [re] });
+  const sec = new Section({ phrases: [p1, p2] });
+
+  expect(sec.allPitches(false).length).toBe(2);
+  expect(sec.trajectories).toEqual([sa1, sa2, re]);
 });


### PR DESCRIPTION
## Summary
- verify Section.allPitches removes duplicates
- verify Section.trajectories gathers all trajectories

## Testing
- `npx vitest run` *(fails: compute id7-id13)*

------
https://chatgpt.com/codex/tasks/task_e_685dd3164fa8832ebe6075c236085847