### PR TITLE
Add adjacency and range tests for Group

### DIFF
--- a/src/js/tests/group.test.ts
+++ b/src/js/tests/group.test.ts
@@ -15,3 +15,25 @@ test('Group basics', () => {
   const copy = Group.fromJSON(json);
   expect(copy.trajectories.length).toBe(3);
 });
+
+test('Group constructor throws on non adjacent trajectories', () => {
+  const t1 = new Trajectory({ num: 0, phraseIdx: 0, pitches: [new Pitch()] });
+  const t2 = new Trajectory({ num: 2, phraseIdx: 0, pitches: [new Pitch({ swara: 'r' })] });
+  expect(() => new Group({ trajectories: [t1, t2] })).toThrow('Trajectories are not adjacent');
+});
+
+test('addTraj enforces adjacency', () => {
+  const t1 = new Trajectory({ num: 0, phraseIdx: 0, pitches: [new Pitch()] });
+  const t2 = new Trajectory({ num: 1, phraseIdx: 0, pitches: [new Pitch({ swara: 'r' })] });
+  const g = new Group({ trajectories: [t1, t2] });
+  const t3 = new Trajectory({ num: 3, phraseIdx: 0, pitches: [new Pitch({ swara: 'g' })] });
+  expect(() => g.addTraj(t3)).toThrow('Trajectories are not adjacent');
+});
+
+test('Group minFreq and maxFreq use trajectory ranges', () => {
+  const low = new Trajectory({ num: 0, phraseIdx: 0, pitches: [new Pitch({ fundamental: 200 })] });
+  const high = new Trajectory({ num: 1, phraseIdx: 0, pitches: [new Pitch({ fundamental: 400 })] });
+  const g = new Group({ trajectories: [low, high] });
+  expect(g.minFreq).toBeCloseTo(low.minFreq);
+  expect(g.maxFreq).toBeCloseTo(high.maxFreq);
+});

--- a/src/js/tests/trajectory.test.ts
+++ b/src/js/tests/trajectory.test.ts
@@ -92,9 +92,33 @@ test('compute id7-id13', () => {
   const vib = { periods: 2, vertOffset: 0, initUp: true, extent: 0.1 };
   const t13 = new Trajectory({ id: 13, vibObj: vib });
   pts.forEach(x => {
-    /* expected13 logic copied verbatim from original test */
-    /* … */
-    expect(t13.id13(x)).toBeCloseTo(/* expected13(x) */);
+    const expected13 = (xVal: number): number => {
+      const { periods, vertOffset, initUp, extent } = vib;
+      let vo = vertOffset;
+      if (Math.abs(vo) > extent / 2) {
+        vo = Math.sign(vo) * extent / 2;
+      }
+      let out = Math.cos(xVal * 2 * Math.PI * periods + Number(initUp) * Math.PI);
+      const base = Math.log2(t13.freqs[0]);
+      if (xVal < 1 / (2 * periods)) {
+        const start = base;
+        const end = Math.log2(expected13(1 / (2 * periods)));
+        const middle = (end + start) / 2;
+        const ext = Math.abs(end - start) / 2;
+        out = out * ext + middle;
+        return 2 ** out;
+      } else if (xVal > 1 - 1 / (2 * periods)) {
+        const start = Math.log2(expected13(1 - 1 / (2 * periods)));
+        const end = base;
+        const middle = (end + start) / 2;
+        const ext = Math.abs(end - start) / 2;
+        out = out * ext + middle;
+        return 2 ** out;
+      } else {
+        return 2 ** (out * extent / 2 + vo + base);
+      }
+    };
+    expect(t13.id13(x)).toBeCloseTo(expected13(x));
   });
 });
 


### PR DESCRIPTION
## Summary
- extend `group.test.ts` to cover non-adjacent errors
- check `minFreq` and `maxFreq` using different trajectories
- implement missing expectation for trajectory vibrato

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685dd308a458832e8ac9e1037bfce20c