### PR TITLE
Add Pitch helper tests

### DIFF
--- a/src/js/tests/pitch.test.ts
+++ b/src/js/tests/pitch.test.ts
@@ -264,3 +264,58 @@ test('numberedPitch', () => {
   p = new Pitch({ swara: 3, raised: false, oct: 1 })
   expect(p.numberedPitch).toEqual(17);
 })
+
+test('sameAs', () => {
+  const p1 = new Pitch({ swara: 're', raised: false, oct: 1 });
+  const p2 = new Pitch({ swara: 1, raised: false, oct: 1 });
+  const p3 = new Pitch({ swara: 1, raised: true, oct: 1 });
+  expect(p1.sameAs(p2)).toBe(true);
+  expect(p1.sameAs(p3)).toBe(false);
+})
+
+test('fromPitchNumber and helpers', () => {
+  let p = Pitch.fromPitchNumber(4);
+  expect(p.swara).toEqual(2);
+  expect(p.raised).toEqual(true);
+  expect(p.oct).toEqual(0);
+
+  p = Pitch.fromPitchNumber(-1);
+  expect(p.swara).toEqual(6);
+  expect(p.raised).toEqual(true);
+  expect(p.oct).toEqual(-1);
+
+  expect(Pitch.pitchNumberToChroma(14)).toEqual(2);
+  expect(Pitch.pitchNumberToChroma(-1)).toEqual(11);
+
+  let sd, raised;
+  [sd, raised] = Pitch.chromaToScaleDegree(3);
+  expect(sd).toEqual(2);
+  expect(raised).toEqual(false);
+  [sd, raised] = Pitch.chromaToScaleDegree(11);
+  expect(sd).toEqual(6);
+  expect(raised).toEqual(true);
+})
+
+test('display properties', () => {
+  const pDown = new Pitch({ swara: 'g', raised: false, oct: -1 });
+  expect(pDown.solfegeLetter).toEqual('Me');
+  expect(pDown.octavedScaleDegree).toEqual('3\u0323');
+  expect(pDown.octavedSolfegeLetter).toEqual('Me\u0323');
+  expect(pDown.octavedSolfegeLetterWithCents).toEqual('Me\u0323 (+0\u00A2)');
+  expect(pDown.octavedChroma).toEqual('3\u0323');
+  expect(pDown.octavedChromaWithCents).toEqual('3\u0323 (+0\u00A2)');
+  expect(pDown.centsString).toEqual('+0\u00A2');
+  expect(pDown.a440CentsDeviation).toEqual('D#3 (+0\u00A2)');
+  expect(pDown.movableCCentsDeviation).toEqual('D# (+0\u00A2)');
+
+  const pUp = new Pitch({ swara: 'Sa', oct: 2 });
+  expect(pUp.solfegeLetter).toEqual('Do');
+  expect(pUp.octavedScaleDegree).toEqual('1\u0308');
+  expect(pUp.octavedSolfegeLetter).toEqual('Do\u0308');
+  expect(pUp.octavedSolfegeLetterWithCents).toEqual('Do\u0308 (+0\u00A2)');
+  expect(pUp.octavedChroma).toEqual('0\u0308');
+  expect(pUp.octavedChromaWithCents).toEqual('0\u0308 (+0\u00A2)');
+  expect(pUp.centsString).toEqual('+0\u00A2');
+  expect(pUp.a440CentsDeviation).toEqual('C6 (+0\u00A2)');
+  expect(pUp.movableCCentsDeviation).toEqual('C (+0\u00A2)');
+})

--- a/src/js/tests/trajectory.test.ts
+++ b/src/js/tests/trajectory.test.ts
@@ -91,10 +91,35 @@ test('compute id7-id13', () => {
 
   const vib = { periods: 2, vertOffset: 0, initUp: true, extent: 0.1 };
   const t13 = new Trajectory({ id: 13, vibObj: vib });
+  const expected13 = (x: number): number => {
+    const periods = vib.periods;
+    let vertOffset = vib.vertOffset;
+    const initUp = vib.initUp;
+    const extent = vib.extent;
+    if (Math.abs(vertOffset) > extent / 2) {
+      vertOffset = Math.sign(vertOffset) * extent / 2;
+    }
+    let out = Math.cos(x * 2 * Math.PI * periods + Number(initUp) * Math.PI);
+    if (x < 1 / (2 * periods)) {
+      const start = t13.logFreqs[0];
+      const end = Math.log2(expected13(1 / (2 * periods)));
+      const middle = (end + start) / 2;
+      const ext = Math.abs(end - start) / 2;
+      out = out * ext + middle;
+      return 2 ** out;
+    } else if (x > 1 - 1 / (2 * periods)) {
+      const start = Math.log2(expected13(1 - 1 / (2 * periods)));
+      const end = t13.logFreqs[0];
+      const middle = (end + start) / 2;
+      const ext = Math.abs(end - start) / 2;
+      out = out * ext + middle;
+      return 2 ** out;
+    } else {
+      return 2 ** (out * extent / 2 + vertOffset + t13.logFreqs[0]);
+    }
+  };
   pts.forEach(x => {
-    /* expected13 logic copied verbatim from original test */
-    /* … */
-    expect(t13.id13(x)).toBeCloseTo(/* expected13(x) */);
+    expect(t13.id13(x)).toBeCloseTo(expected13(x));
   });
 });
 


### PR DESCRIPTION
## Summary
- expand `pitch.test.ts` with checks for comparison helpers, static helpers and display properties
- implement missing expectations for trajectory vibrato test

## Testing
- `pnpm install`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_685dd2f2d5e0832e9bd4a5c0c81035da