### PR TITLE
Add additional Raga tests

### DIFF
--- a/src/js/tests/raga.test.ts
+++ b/src/js/tests/raga.test.ts
@@ -181,3 +181,53 @@ test('defaultRaga', () => {
   };
   expect(r.toJSON()).toEqual(json_obj);
 })
+
+test('pitchFromLogFreq', () => {
+  const r = new Raga();
+  const offset = 0.03;
+  const baseLog = Math.log2(r.fundamental * 2);
+  const p = r.pitchFromLogFreq(baseLog + offset);
+  expect(p).toBeInstanceOf(Pitch);
+  expect(p.frequency).toBeCloseTo(2 ** (baseLog + offset));
+})
+
+test('pitch string getters', () => {
+  const r = new Raga();
+  const pl = r.getPitches({ low: r.fundamental, high: r.fundamental * 1.999 });
+  const solfege = pl.map(p => p.solfegeLetter);
+  const pcs = pl.map(p => p.chroma.toString());
+  const western = pl.map(p => p.westernPitch);
+  expect(r.solfegeStrings).toEqual(solfege);
+  expect(r.pcStrings).toEqual(pcs);
+  expect(r.westernPitchStrings).toEqual(western);
+})
+
+test('swaraObjects', () => {
+  const r = new Raga();
+  const objs = [
+    { swara: 0, raised: true },
+    { swara: 1, raised: true },
+    { swara: 2, raised: true },
+    { swara: 3, raised: true },
+    { swara: 4, raised: true },
+    { swara: 5, raised: true },
+    { swara: 6, raised: true },
+  ];
+  expect(r.swaraObjects).toEqual(objs);
+})
+
+test('ratioIdxToTuningTuple', () => {
+  const r = new Raga();
+  const mapping: Array<[string, string | undefined]> = [
+    ['sa', undefined],
+    ['re', 'raised'],
+    ['ga', 'raised'],
+    ['ma', 'raised'],
+    ['pa', undefined],
+    ['dha', 'raised'],
+    ['ni', 'raised'],
+  ];
+  mapping.forEach((tuple, idx) => {
+    expect(r.ratioIdxToTuningTuple(idx)).toEqual(tuple);
+  });
+})

--- a/src/js/tests/trajectory.test.ts
+++ b/src/js/tests/trajectory.test.ts
@@ -91,10 +91,36 @@ test('compute id7-id13', () => {
 
   const vib = { periods: 2, vertOffset: 0, initUp: true, extent: 0.1 };
   const t13 = new Trajectory({ id: 13, vibObj: vib });
+  const log0 = Math.log2(261.63);
+  const expected13 = (x: number): number => {
+    const periods = vib.periods;
+    let vertOffset = vib.vertOffset;
+    const initUp = vib.initUp;
+    const extent = vib.extent;
+    if (Math.abs(vertOffset) > extent / 2) {
+      vertOffset = Math.sign(vertOffset) * extent / 2;
+    }
+    let out = Math.cos(x * 2 * Math.PI * periods + Number(initUp) * Math.PI);
+    if (x < 1 / (2 * periods)) {
+      const start = log0;
+      const end = Math.log2(expected13(1 / (2 * periods)));
+      const middle = (end + start) / 2;
+      const ext = Math.abs(end - start) / 2;
+      out = out * ext + middle;
+      return 2 ** out;
+    } else if (x > 1 - 1 / (2 * periods)) {
+      const start = Math.log2(expected13(1 - 1 / (2 * periods)));
+      const end = log0;
+      const middle = (end + start) / 2;
+      const ext = Math.abs(end - start) / 2;
+      out = out * ext + middle;
+      return 2 ** out;
+    } else {
+      return 2 ** (out * extent / 2 + vertOffset + log0);
+    }
+  };
   pts.forEach(x => {
-    /* expected13 logic copied verbatim from original test */
-    /* … */
-    expect(t13.id13(x)).toBeCloseTo(/* expected13(x) */);
+    expect(t13.id13(x)).toBeCloseTo(expected13(x));
   });
 });
 


### PR DESCRIPTION
## Summary
- test `pitchFromLogFreq` output frequency
- ensure string getter arrays match output of `getPitches`
- verify `swaraObjects` mapping and `ratioIdxToTuningTuple`
- implement expected logic for `Trajectory.id13` test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685dd2f5b4a8832ebb98ff7aeb43609b