### PR TITLE
Add error message checks in Piece tests

### DIFF
--- a/src/js/tests/piece.test.ts
+++ b/src/js/tests/piece.test.ts
@@ -454,7 +454,7 @@ function buildGroupedPiece() {
 
 test('trackFromTrajUId throws when id not found', () => {
   const { piece } = buildSimplePieceFull();
-  expect(() => piece.trackFromTrajUId('missing')).toThrow();
+  expect(() => piece.trackFromTrajUId('missing')).toThrow('Trajectory not found');
 });
 
 test('pIdxFromGroup works across phrases', () => {
@@ -482,7 +482,7 @@ test('addMeter overlap detection and removeMeter correctness', () => {
   piece.addMeter(m1);
   piece.addMeter(m2);
   const overlap = new Meter({ startTime: 3, tempo: 60 });
-  expect(() => piece.addMeter(overlap)).toThrow();
+  expect(() => piece.addMeter(overlap)).toThrow('meters overlap');
 
   piece.removeMeter(m1);
   expect(piece.meters.length).toBe(1);


### PR DESCRIPTION
## Summary
- add explicit error message expectations for `trackFromTrajUId`
- verify overlapping meter errors include the expected message

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e0b06d4c0832ebd6bae6fb1c27746