### PR TITLE
Add stroke nickname test for r

### DIFF
--- a/src/js/tests/articulation.test.ts
+++ b/src/js/tests/articulation.test.ts
@@ -17,3 +17,14 @@ test('Articulation fromJSON', () => {
   expect(a.stroke).toBe('d');
   expect(a.strokeNickname).toBe('da');
 });
+
+test('stroke r sets strokeNickname', () => {
+  const a = new Articulation({ stroke: 'r' });
+  expect(a.strokeNickname).toBe('ra');
+});
+
+test('stroke r via fromJSON sets strokeNickname', () => {
+  const obj = { name: 'pluck', stroke: 'r' };
+  const a = Articulation.fromJSON(obj);
+  expect(a.strokeNickname).toBe('ra');
+});


### PR DESCRIPTION
## Summary
- add coverage for stroke 'r' in Articulation tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685e14d9e5a4832e805ecd4339cb5327