### PR TITLE
Add articulation stroke nickname default test

### DIFF
--- a/src/js/tests/articulation.test.ts
+++ b/src/js/tests/articulation.test.ts
@@ -17,3 +17,13 @@ test('Articulation fromJSON', () => {
   expect(a.stroke).toBe('d');
   expect(a.strokeNickname).toBe('da');
 });
+
+test('strokeNickname defaults to da for d stroke', () => {
+  const a = new Articulation({ stroke: 'd' });
+  expect(a.strokeNickname).toBe('da');
+  expect(a.name).toBe('pluck');
+  expect(a.stroke).toBe('d');
+  expect(a.hindi).toBeUndefined();
+  expect(a.ipa).toBeUndefined();
+  expect(a.engTrans).toBeUndefined();
+});


### PR DESCRIPTION
## Summary
- expand articulation tests
- verify strokeNickname defaults to 'da' when stroke is 'd'

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685e14d88d2c832e815cbca393526449