### PR TITLE
Add pitchFromLogFreq rounding test

### DIFF
--- a/src/js/tests/raga.test.ts
+++ b/src/js/tests/raga.test.ts
@@ -310,6 +310,15 @@ test('pitchFromLogFreq octave rounding', () => {
   expect(p2.oct).toBe(1);
 })
 
+test('pitchFromLogFreq near exact octave offset', () => {
+  const fundamental = 128.5 - 1e-12;
+  const r = new Raga({ fundamental });
+  const logFreq = Math.log2(fundamental * 2);
+  const p = r.pitchFromLogFreq(logFreq);
+  expect(p.sargamLetter).toBe('S');
+  expect(p.oct).toBe(1);
+})
+
 test('ratioIdxToTuningTuple mixed rule set', () => {
   const r = new Raga({ ruleSet: customRuleSet });
   const mapping: Array<[string, string | undefined]> = [


### PR DESCRIPTION
## Summary
- add a new test for `pitchFromLogFreq` with a fundamental value that triggers the octave rounding branch

## Testing
- `npx vitest run src/js/tests/raga.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_685e9d6bd0c4832ea64358db6a3da254