### PR TITLE
Add model raga conversion tests

### DIFF
--- a/src/js/tests/raga.addition.test.ts
+++ b/src/js/tests/raga.addition.test.ts
@@ -112,3 +112,26 @@ test('pitchNumberToScaleNumber edge cases', () => {
     expect(() => r.pitchNumberToScaleNumber(pn)).toThrow();
   });
 });
+
+test('raga conversion helpers', () => {
+  const r = new Raga({ ruleSet, fundamental });
+  const pitchNumbers = [0, 1, 4, 5, 6, 7, 9, 10];
+  const letters = ['S', 'r', 'G', 'm', 'M', 'P', 'D', 'n'];
+
+  pitchNumbers.forEach((pn, idx) => {
+    expect(r.pitchNumberToSargamLetter(pn)).toBe(letters[idx]);
+    expect(r.pitchNumberToScaleNumber(pn)).toBe(idx);
+    expect(r.scaleNumberToPitchNumber(idx)).toBe(pn);
+    expect(r.scaleNumberToSargamLetter(idx)).toBe(letters[idx]);
+  });
+
+  const len = pitchNumbers.length;
+  expect(r.scaleNumberToPitchNumber(len)).toBe(pitchNumbers[0] + 12);
+  expect(r.scaleNumberToPitchNumber(len + 1)).toBe(pitchNumbers[1] + 12);
+
+  const invalidPNs = [2, 3, 8, 11];
+  invalidPNs.forEach(pn => {
+    expect(r.pitchNumberToSargamLetter(pn)).toBeUndefined();
+    expect(() => r.pitchNumberToScaleNumber(pn)).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- extend raga.addition.test.ts to cover conversion helpers on model Raga
  - `pitchNumberToSargamLetter`
  - `scaleNumberToPitchNumber`
  - `pitchNumberToScaleNumber`
  - `scaleNumberToSargamLetter`
- check valid conversions and invalid inputs

## Testing
- `npx vitest run src/js/tests/raga.addition.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_685e9d691540832ea8151192ae64933f