### PR TITLE
Add test for ModelRaga string getters

### DIFF
--- a/src/js/tests/raga.model.strings.test.ts
+++ b/src/js/tests/raga.model.strings.test.ts
@@ -1,0 +1,16 @@
+import { expect, test } from 'vitest';
+import { Raga } from '@model';
+
+// Ensure solfegeStrings, pcStrings, and westernPitchStrings
+// match the values computed from getPitches()
+
+test('model raga string getters', () => {
+  const r = new Raga();
+  const pl = r.getPitches({ low: r.fundamental, high: r.fundamental * 1.999 });
+  const solfege = pl.map(p => p.solfegeLetter);
+  const pcs = pl.map(p => p.chroma.toString());
+  const western = pl.map(p => p.westernPitch);
+  expect(r.solfegeStrings).toEqual(solfege);
+  expect(r.pcStrings).toEqual(pcs);
+  expect(r.westernPitchStrings).toEqual(western);
+});


### PR DESCRIPTION
## Summary
- add a test verifying the `solfegeStrings`, `pcStrings`, and `westernPitchStrings` getters on the model `Raga` class

## Testing
- `npx vitest run src/js/tests/raga.model.strings.test.ts`
- `npm test` *(fails: Unexpected end of file in src/js/tests/articulation.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_685e9d67e820832ea7dbd51d29a6f284