### PR TITLE
Add missing articulation test end and new allDisplayVowels error check

### DIFF
--- a/src/js/tests/articulation.test.ts
+++ b/src/js/tests/articulation.test.ts
@@ -26,7 +26,8 @@ test('strokeNickname defaults to da for d stroke', () => {
   expect(a.hindi).toBeUndefined();
   expect(a.ipa).toBeUndefined();
   expect(a.engTrans).toBeUndefined();
-  
+});
+
 test('stroke r sets strokeNickname', () => {
   const a = new Articulation({ stroke: 'r' });
   expect(a.strokeNickname).toBe('ra');

--- a/src/js/tests/piece.test.ts
+++ b/src/js/tests/piece.test.ts
@@ -488,3 +488,12 @@ test('addMeter overlap detection and removeMeter correctness', () => {
   expect(piece.meters.length).toBe(1);
   expect(piece.meters[0]).toBe(m2);
 });
+
+test('allDisplayVowels throws for non-vocal instrumentation', () => {
+  const raga = new Raga();
+  const traj = new Trajectory({ num: 0, pitches: [new Pitch()], durTot: 1 });
+  const phrase = new Phrase({ trajectories: [traj], raga });
+  const piece = new Piece({ phrases: [phrase], raga, instrumentation: [Instrument.Sitar] });
+
+  expect(() => piece.allDisplayVowels()).toThrow('instrumentation is not vocal');
+});


### PR DESCRIPTION
## Summary
- close a test block in `articulation.test.ts`
- verify `allDisplayVowels` throws on non‑vocal instrumentation

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_685e9d5aae14832e9dfffd55fe397eec