### PR TITLE
Add test coverage for piece pitch checks

### DIFF
--- a/src/js/tests/articulation.test.ts
+++ b/src/js/tests/articulation.test.ts
@@ -26,6 +26,7 @@ test('strokeNickname defaults to da for d stroke', () => {
   expect(a.hindi).toBeUndefined();
   expect(a.ipa).toBeUndefined();
   expect(a.engTrans).toBeUndefined();
+});
   
 test('stroke r sets strokeNickname', () => {
   const a = new Articulation({ stroke: 'r' });

--- a/src/js/tests/piece.test.ts
+++ b/src/js/tests/piece.test.ts
@@ -488,3 +488,31 @@ test('addMeter overlap detection and removeMeter correctness', () => {
   expect(piece.meters.length).toBe(1);
   expect(piece.meters[0]).toBe(m2);
 });
+
+
+test('allPitches throws when a pitch array contains a number', () => {
+  const raga = new Raga();
+  const traj = new Trajectory({ num: 0, pitches: [new Pitch()], durTot: 1 });
+  (traj.pitches as any).push(0);
+  const phrase = new Phrase({ trajectories: [traj], raga });
+  const piece = new Piece({ phrases: [phrase], raga, instrumentation: [Instrument.Sitar] });
+  expect(() => piece.allPitches({ repetition: false })).toThrow('pitch is a number');
+});
+
+test('allPitches returns numbers with pitchNumber option', () => {
+  const piece = buildSimplePiece();
+  const nums = piece.allPitches({ pitchNumber: true }) as number[];
+  expect(nums.every(n => typeof n === 'number')).toBe(true);
+  expect(nums.length).toBeGreaterThan(0);
+});
+
+test('trajFromTime after last trajectory returns undefined', () => {
+  const piece = buildSimplePiece();
+  const after = (piece.durTot ?? 0) + 1;
+  expect(piece.trajFromTime(after, 0)).toBeUndefined();
+});
+
+test('trajFromUId throws when not found', () => {
+  const piece = buildSimplePiece();
+  expect(() => piece.trajFromUId('missing', 0)).toThrow('Trajectory not found');
+});


### PR DESCRIPTION
## Summary
- fix articulation tests
- add piece tests for numeric pitch, pitchNumber output, trajFromTime boundary, and trajFromUId error

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685e9d58e434832eaeea63c68bfd7b1e