### PR TITLE
Add negative tests for Piece lookup utilities

### DIFF
--- a/src/js/tests/articulation.test.ts
+++ b/src/js/tests/articulation.test.ts
@@ -18,15 +18,15 @@ test('Articulation fromJSON', () => {
   expect(a.strokeNickname).toBe('da');
 });
 
-test('strokeNickname defaults to da for d stroke', () => {
-  const a = new Articulation({ stroke: 'd' });
-  expect(a.strokeNickname).toBe('da');
-  expect(a.name).toBe('pluck');
-  expect(a.stroke).toBe('d');
-  expect(a.hindi).toBeUndefined();
-  expect(a.ipa).toBeUndefined();
-  expect(a.engTrans).toBeUndefined();
-  
+  test('strokeNickname defaults to da for d stroke', () => {
+    const a = new Articulation({ stroke: 'd' });
+    expect(a.strokeNickname).toBe('da');
+    expect(a.name).toBe('pluck');
+    expect(a.stroke).toBe('d');
+    expect(a.hindi).toBeUndefined();
+    expect(a.ipa).toBeUndefined();
+    expect(a.engTrans).toBeUndefined();
+  });
 test('stroke r sets strokeNickname', () => {
   const a = new Articulation({ stroke: 'r' });
   expect(a.strokeNickname).toBe('ra');

--- a/src/js/tests/piece.test.ts
+++ b/src/js/tests/piece.test.ts
@@ -488,3 +488,15 @@ test('addMeter overlap detection and removeMeter correctness', () => {
   expect(piece.meters.length).toBe(1);
   expect(piece.meters[0]).toBe(m2);
 });
+
+test('trackFromTraj throws when trajectory not found', () => {
+  const { piece } = buildSimplePieceFull();
+  const missing = new Trajectory({ num: 99, pitches: [new Pitch()], durTot: 1 });
+  expect(() => piece.trackFromTraj(missing)).toThrow('Trajectory not found');
+});
+
+test('phraseFromUId and trackFromPhraseUId throw when id not found', () => {
+  const { piece } = buildSimplePieceFull();
+  expect(() => piece.phraseFromUId('missing')).toThrow('Phrase not found');
+  expect(() => piece.trackFromPhraseUId('missing')).toThrow('Phrase not found');
+});


### PR DESCRIPTION
## Summary
- fix articulation tests syntax
- test `trackFromTraj` error branch
- test `phraseFromUId` and `trackFromPhraseUId` error branches

## Testing
- `npm test`
- `python -m pytest python/api/tests`


------
https://chatgpt.com/codex/tasks/task_e_685e9d57a03c832eaaa9c92abb04230b