### PR TITLE
Add durStarts error tests

### DIFF
--- a/src/js/tests/articulation.test.ts
+++ b/src/js/tests/articulation.test.ts
@@ -26,6 +26,7 @@ test('strokeNickname defaults to da for d stroke', () => {
   expect(a.hindi).toBeUndefined();
   expect(a.ipa).toBeUndefined();
   expect(a.engTrans).toBeUndefined();
+});
   
 test('stroke r sets strokeNickname', () => {
   const a = new Articulation({ stroke: 'r' });

--- a/src/js/tests/piece.test.ts
+++ b/src/js/tests/piece.test.ts
@@ -488,3 +488,19 @@ test('addMeter overlap detection and removeMeter correctness', () => {
   expect(piece.meters.length).toBe(1);
   expect(piece.meters[0]).toBe(m2);
 });
+
+test('durStarts throws when durArray is missing', () => {
+  const piece = buildSimplePiece();
+  // @ts-ignore - simulate deleted property
+  piece.durArray = undefined;
+  expect(() => piece.durStarts()).toThrow('durArray is undefined');
+});
+
+test('durStarts throws when durTot is missing', () => {
+  const piece = buildSimplePiece();
+  // Ensure durArray exists
+  piece.durArray = [0.5, 0.5];
+  // @ts-ignore - remove durTot
+  piece.durTot = undefined;
+  expect(() => piece.durStarts()).toThrow('durTot is undefined');
+});


### PR DESCRIPTION
## Summary
- fix a missing closing brace in `articulation.test.ts`
- add tests for `Piece.durStarts()` error branches when `durArray` or `durTot` are undefined

## Testing
- `pnpm vitest run`

------
https://chatgpt.com/codex/tasks/task_e_685e9d560bf0832e935394b57ea1596b