### PR TITLE
Add tests for durationsOfFixedPitches helper

### DIFF
--- a/src/js/tests/articulation.test.ts
+++ b/src/js/tests/articulation.test.ts
@@ -26,7 +26,8 @@ test('strokeNickname defaults to da for d stroke', () => {
   expect(a.hindi).toBeUndefined();
   expect(a.ipa).toBeUndefined();
   expect(a.engTrans).toBeUndefined();
-  
+});
+
 test('stroke r sets strokeNickname', () => {
   const a = new Articulation({ stroke: 'r' });
   expect(a.strokeNickname).toBe('ra');

--- a/src/js/tests/piece.test.ts
+++ b/src/js/tests/piece.test.ts
@@ -14,6 +14,7 @@ import {
   Chikari,
   Assemblage,
   initSecCategorization,
+  durationsOfFixedPitches,
 } from '@model';              // ← adjust if your alias is different
 import { Meter } from '@/js/meter'; // or '../meter'
 import { Instrument } from '@shared/enums';
@@ -487,4 +488,30 @@ test('addMeter overlap detection and removeMeter correctness', () => {
   piece.removeMeter(m1);
   expect(piece.meters.length).toBe(1);
   expect(piece.meters[0]).toBe(m2);
+});
+
+// -------------------------------------------------------
+//  Tests for standalone durationsOfFixedPitches helper
+// -------------------------------------------------------
+
+test('durationsOfFixedPitches throws SyntaxError for invalid traj output', () => {
+  const badTraj = {
+    durationsOfFixedPitches: () => 5,
+  } as unknown as Trajectory;
+
+  expect(() => durationsOfFixedPitches([badTraj])).toThrow(SyntaxError);
+});
+
+test('durationsOfFixedPitches proportional count normalizes totals', () => {
+  const t1 = new Trajectory({ id: 0, pitches: [new Pitch({ swara: 0 })], durTot: 1 });
+  const t2 = new Trajectory({ id: 0, pitches: [new Pitch({ swara: 1 })], durTot: 2 });
+  const np1 = t1.pitches[0].numberedPitch;
+  const np2 = t2.pitches[0].numberedPitch;
+
+  const result = durationsOfFixedPitches([t1, t2], { countType: 'proportional' });
+
+  expect(result[np1]).toBeCloseTo(1 / 3);
+  expect(result[np2]).toBeCloseTo(2 / 3);
+  const total = Object.values(result).reduce((a, b) => a + (b as number), 0);
+  expect(total).toBeCloseTo(1);
 });


### PR DESCRIPTION
## Summary
- import `durationsOfFixedPitches` in piece tests
- close a missing test block in `articulation.test.ts`
- add standalone `durationsOfFixedPitches` tests for error handling and proportional counts

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_685e9d50d018832eb182542fc5220e7a