### PR TITLE
Add extreme octave display tests

### DIFF
--- a/src/js/tests/articulation.test.ts
+++ b/src/js/tests/articulation.test.ts
@@ -26,7 +26,8 @@ test('strokeNickname defaults to da for d stroke', () => {
   expect(a.hindi).toBeUndefined();
   expect(a.ipa).toBeUndefined();
   expect(a.engTrans).toBeUndefined();
-  
+});
+
 test('stroke r sets strokeNickname', () => {
   const a = new Articulation({ stroke: 'r' });
   expect(a.strokeNickname).toBe('ra');

--- a/src/js/tests/pitch.test.ts
+++ b/src/js/tests/pitch.test.ts
@@ -454,6 +454,17 @@ test('a440CentsDeviation and movableCCentsDeviation edge octaves', () => {
   }
 });
 
+test('octaved display strings extreme octaves', () => {
+  const low = new Pitch({ swara: 'Sa', oct: -3 });
+  const high = new Pitch({ swara: 'Sa', oct: 3 });
+  expect(low.octavedSargamLetter).toBe('S\u20E8');
+  expect(high.octavedSargamLetter).toBe('S\u20DB');
+  expect(low.octavedSolfegeLetter).toBe('Do\u20E8');
+  expect(high.octavedSolfegeLetter).toBe('Do\u20DB');
+  expect(low.octavedChroma).toBe('0\u20E8');
+  expect(high.octavedChroma).toBe('0\u20DB');
+});
+
 test('numberedPitch invalid swara values', () => {
   const p = new Pitch();
   (p as any).swara = -1;


### PR DESCRIPTION
## Summary
- fix missing closing brace in `articulation.test.ts`
- test string outputs for extreme octaves in `pitch.test.ts`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e9d3caa80832e934b11e1bd70ff50