### PR TITLE
Add pitch constructor error tests

### DIFF
--- a/src/js/tests/articulation.test.ts
+++ b/src/js/tests/articulation.test.ts
@@ -26,7 +26,8 @@ test('strokeNickname defaults to da for d stroke', () => {
   expect(a.hindi).toBeUndefined();
   expect(a.ipa).toBeUndefined();
   expect(a.engTrans).toBeUndefined();
-  
+});
+
 test('stroke r sets strokeNickname', () => {
   const a = new Articulation({ stroke: 'r' });
   expect(a.strokeNickname).toBe('ra');

--- a/src/js/tests/pitch.test.ts
+++ b/src/js/tests/pitch.test.ts
@@ -389,6 +389,9 @@ test('constructor error conditions', () => {
   expect(() => new Pitch({ raised: 1 as any })).toThrow(SyntaxError);
   expect(() => new Pitch({ swara: [] as any })).toThrow(SyntaxError);
   expect(() => new Pitch({ swara: 'foo' })).toThrow(SyntaxError);
+  expect(() => new Pitch({ swara: 'x' })).toThrow(SyntaxError);
+  expect(() => new Pitch({ swara: -1 })).toThrow(SyntaxError);
+  expect(() => new Pitch({ swara: 7 })).toThrow(SyntaxError);
 });
 
 test('setOct invalid swara and ratio inputs', () => {


### PR DESCRIPTION
## Summary
- test pitch constructor with invalid swara values `'x'`, `-1`, and `7`
- fix missing bracket in `articulation.test.ts`

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_685e9d36716c832e9375919cc23c8cbe