### PR TITLE
Add undefined ratio tests

### DIFF
--- a/src/js/tests/articulation.test.ts
+++ b/src/js/tests/articulation.test.ts
@@ -26,7 +26,8 @@ test('strokeNickname defaults to da for d stroke', () => {
   expect(a.hindi).toBeUndefined();
   expect(a.ipa).toBeUndefined();
   expect(a.engTrans).toBeUndefined();
-  
+});
+
 test('stroke r sets strokeNickname', () => {
   const a = new Articulation({ stroke: 'r' });
   expect(a.strokeNickname).toBe('ra');

--- a/src/js/tests/pitch.test.ts
+++ b/src/js/tests/pitch.test.ts
@@ -484,3 +484,23 @@ test('invalid ratio values trigger errors', () => {
   expect(() => badGa.frequency).toThrow(SyntaxError);
   expect(() => badGa.setOct(0)).toThrow(SyntaxError);
 });
+
+test('constructor rejects undefined ratios', () => {
+  const baseRatios = [
+    1,
+    [2 ** (1 / 12), 2 ** (2 / 12)],
+    [2 ** (3 / 12), 2 ** (4 / 12)],
+    [2 ** (5 / 12), 2 ** (6 / 12)],
+    2 ** (7 / 12),
+    [2 ** (8 / 12), 2 ** (9 / 12)],
+    [2 ** (10 / 12), 2 ** (11 / 12)]
+  ];
+
+  const ratios1 = [...baseRatios];
+  ratios1[0] = undefined as any;
+  expect(() => new Pitch({ ratios: ratios1 as any })).toThrow(SyntaxError);
+
+  const ratios2 = [...baseRatios];
+  ratios2[1] = [2 ** (1 / 12), undefined] as any;
+  expect(() => new Pitch({ ratios: ratios2 as any })).toThrow(SyntaxError);
+});


### PR DESCRIPTION
## Summary
- extend pitch tests to check constructor behaviour with undefined ratios
- fix articulation tests by closing a missing bracket

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e9d35c308832e93630136b98679f1