### PR TITLE
Add tests for consolidateSilentTrajs

### DIFF
--- a/src/js/tests/articulation.test.ts
+++ b/src/js/tests/articulation.test.ts
@@ -26,12 +26,13 @@ test('strokeNickname defaults to da for d stroke', () => {
   expect(a.hindi).toBeUndefined();
   expect(a.ipa).toBeUndefined();
   expect(a.engTrans).toBeUndefined();
-  
+});
+
 test('stroke r sets strokeNickname', () => {
   const a = new Articulation({ stroke: 'r' });
   expect(a.strokeNickname).toBe('ra');
 });
-
+  
 test('stroke r via fromJSON sets strokeNickname', () => {
   const obj = { name: 'pluck', stroke: 'r' };
   const a = Articulation.fromJSON(obj);

--- a/src/js/tests/phrase.test.ts
+++ b/src/js/tests/phrase.test.ts
@@ -161,3 +161,34 @@ test('Phrase utility functions', () => {
   p.consolidateSilentTrajs();
   expect(p.trajectories.length).toBe(3);
 });
+
+test('consolidateSilentTrajs collapses middle and trailing silences', () => {
+  const t1 = new Trajectory({ num: 0, durTot: 0.5, pitches: [new Pitch()] });
+  const s1 = new Trajectory({ num: 1, id: 12, durTot: 0.1, pitches: [new Pitch()] });
+  const s2 = new Trajectory({ num: 2, id: 12, durTot: 0.2, pitches: [new Pitch()] });
+  const t2 = new Trajectory({ num: 3, durTot: 0.5, pitches: [new Pitch({ swara: 'r' })] });
+  const s3 = new Trajectory({ num: 4, id: 12, durTot: 0.1, pitches: [new Pitch()] });
+  const s4 = new Trajectory({ num: 5, id: 12, durTot: 0.2, pitches: [new Pitch()] });
+  const t3 = new Trajectory({ num: 6, durTot: 0.5, pitches: [new Pitch({ swara: 'g' })] });
+  const s5 = new Trajectory({ num: 7, id: 12, durTot: 0.1, pitches: [new Pitch()] });
+  const s6 = new Trajectory({ num: 8, id: 12, durTot: 0.2, pitches: [new Pitch()] });
+
+  const p = new Phrase({
+    trajectories: [t1, s1, s2, t2, s3, s4, t3, s5, s6],
+    raga: new Raga(),
+    startTime: 0,
+  });
+  p.consolidateSilentTrajs();
+  expect(p.trajectories.length).toBe(6);
+  expect(p.trajectories[1].durTot).toBeCloseTo(0.3);
+  expect(p.trajectories[3].durTot).toBeCloseTo(0.3);
+  expect(p.trajectories[5].durTot).toBeCloseTo(0.3);
+});
+
+test('consolidateSilentTrajs throws when traj num missing', () => {
+  const good = new Trajectory({ num: 0, durTot: 0.5, pitches: [new Pitch()] });
+  const badSilent = new Trajectory({ id: 12, durTot: 0.5, pitches: [new Pitch()] });
+  const p = new Phrase({ trajectories: [good, badSilent], raga: new Raga() });
+  p.trajectories[1].num = undefined;
+  expect(() => p.consolidateSilentTrajs()).toThrow('traj.num is undefined');
+});


### PR DESCRIPTION
## Summary
- close unclosed `articulation.test.ts` case
- add tests covering `consolidateSilentTrajs` for collapsing middle and trailing silences
- check error behavior when a trajectory is missing a number

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_685e9d05a04c832e85b654026754c045