### PR TITLE
Add Phrase construction test for custom durations

### DIFF
--- a/src/js/classes.ts
+++ b/src/js/classes.ts
@@ -2114,13 +2114,8 @@ class Phrase {
       }
     }
     if (this.trajectories.length === 0) {
-      if (durTot === undefined) {
-        this.durTot = 1;
-        this.durArray = [];
-      } else {
-        this.durTot = durTot;
-        this.durArray = []
-      }
+      this.durTot = durTot === undefined ? 1 : durTot;
+      this.durArray = durArray === undefined ? [] : durArray;
     } else {
       this.durTotFromTrajectories();
       this.durArrayFromTrajectories();

--- a/src/js/tests/articulation.test.ts
+++ b/src/js/tests/articulation.test.ts
@@ -26,7 +26,8 @@ test('strokeNickname defaults to da for d stroke', () => {
   expect(a.hindi).toBeUndefined();
   expect(a.ipa).toBeUndefined();
   expect(a.engTrans).toBeUndefined();
-  
+});
+
 test('stroke r sets strokeNickname', () => {
   const a = new Articulation({ stroke: 'r' });
   expect(a.strokeNickname).toBe('ra');

--- a/src/js/tests/phrase.test.ts
+++ b/src/js/tests/phrase.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from 'vitest';
+import { expect, test, vi } from 'vitest';
 import {
   Phrase,
   Trajectory,
@@ -160,4 +160,13 @@ test('Phrase utility functions', () => {
   expect(chiks.length).toBe(1);
   p.consolidateSilentTrajs();
   expect(p.trajectories.length).toBe(3);
+});
+
+test('durTot and durArray preserved with empty trajectories', () => {
+  const spy = vi.spyOn(Phrase.prototype as any, 'durArrayFromTrajectories');
+  const p = new Phrase({ durTot: 2, durArray: [1] });
+  expect(p.durTot).toBe(2);
+  expect(p.durArray).toEqual([1]);
+  expect(spy).not.toHaveBeenCalled();
+  spy.mockRestore();
 });

--- a/src/ts/model/phrase.ts
+++ b/src/ts/model/phrase.ts
@@ -131,13 +131,8 @@ class Phrase {
       }
     }
     if (this.trajectories.length === 0) {
-      if (durTot === undefined) {
-        this.durTot = 1;
-        this.durArray = [];
-      } else {
-        this.durTot = durTot;
-        this.durArray = []
-      }
+      this.durTot = durTot === undefined ? 1 : durTot;
+      this.durArray = durArray === undefined ? [] : durArray;
     } else {
       this.durTotFromTrajectories();
       this.durArrayFromTrajectories();


### PR DESCRIPTION
## Summary
- fix Phrase constructor to keep provided `durTot` and `durArray` when no trajectories
- fix stray closing brace in articulation tests
- test durArrayFromTrajectories isn't called when Phrase has no trajectories

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_685e9d013558832e8ecd0a46b0de7372