### PR TITLE
Add Phrase grid padding test

### DIFF
--- a/src/js/tests/articulation.test.ts
+++ b/src/js/tests/articulation.test.ts
@@ -26,7 +26,7 @@ test('strokeNickname defaults to da for d stroke', () => {
   expect(a.hindi).toBeUndefined();
   expect(a.ipa).toBeUndefined();
   expect(a.engTrans).toBeUndefined();
-  
+});
 test('stroke r sets strokeNickname', () => {
   const a = new Articulation({ stroke: 'r' });
   expect(a.strokeNickname).toBe('ra');

--- a/src/js/tests/phrase.test.ts
+++ b/src/js/tests/phrase.test.ts
@@ -161,3 +161,21 @@ test('Phrase utility functions', () => {
   p.consolidateSilentTrajs();
   expect(p.trajectories.length).toBe(3);
 });
+
+test('constructor pads grids to instrumentation length', () => {
+  const t1 = new Trajectory();
+  const trajectoryGrid = [[t1]];
+  const chikariGrid = [{}];
+  const instrumentation = ['Sitar', 'Violin'];
+  const phrase = new Phrase({
+    trajectoryGrid,
+    chikariGrid,
+    instrumentation,
+  });
+  expect(phrase.trajectoryGrid).toBe(trajectoryGrid);
+  expect(phrase.chikariGrid).toBe(chikariGrid);
+  expect(phrase.trajectoryGrid.length).toBe(instrumentation.length);
+  expect(phrase.chikariGrid.length).toBe(instrumentation.length);
+  expect(phrase.trajectoryGrid[1]).toEqual([]);
+  expect(phrase.chikariGrid[1]).toEqual({});
+});


### PR DESCRIPTION
## Summary
- fix incomplete `articulation.test.ts`
- add test verifying that `Phrase` constructor pads trajectory and chikari grids when instrumentation length is greater than the grid length

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_685e9d00e6b0832ead23fe98d96db90c