### PR TITLE
Add Trajectory names test

### DIFF
--- a/src/js/tests/articulation.test.ts
+++ b/src/js/tests/articulation.test.ts
@@ -26,7 +26,8 @@ test('strokeNickname defaults to da for d stroke', () => {
   expect(a.hindi).toBeUndefined();
   expect(a.ipa).toBeUndefined();
   expect(a.engTrans).toBeUndefined();
-  
+});
+
 test('stroke r sets strokeNickname', () => {
   const a = new Articulation({ stroke: 'r' });
   expect(a.strokeNickname).toBe('ra');

--- a/src/ts/tests/trajectory-names.test.ts
+++ b/src/ts/tests/trajectory-names.test.ts
@@ -1,0 +1,8 @@
+import { expect, test } from 'vitest';
+import { Trajectory } from '../model';
+
+test('Trajectory.names matches instance names', () => {
+  const staticNames = Trajectory.names();
+  const instance = new Trajectory();
+  expect(staticNames).toEqual(instance.names);
+});


### PR DESCRIPTION
## Summary
- fix missing closing bracket in articulation test
- add trajectory model test for names()

## Testing
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_685e9cead0f4832e8ac1710aa9f63dab