### PR TITLE
Add failing trajectory stroke type check

### DIFF
--- a/src/js/tests/articulation.test.ts
+++ b/src/js/tests/articulation.test.ts
@@ -26,7 +26,8 @@ test('strokeNickname defaults to da for d stroke', () => {
   expect(a.hindi).toBeUndefined();
   expect(a.ipa).toBeUndefined();
   expect(a.engTrans).toBeUndefined();
-  
+});
+
 test('stroke r sets strokeNickname', () => {
   const a = new Articulation({ stroke: 'r' });
   expect(a.strokeNickname).toBe('ra');

--- a/src/js/tests/trajectory.test.ts
+++ b/src/js/tests/trajectory.test.ts
@@ -211,6 +211,13 @@ test('invalid slope type throws', () => {
   expect(() => new Trajectory({ slope: 'bad' as any })).toThrow('invalid slope type');
 });
 
+test('convertCIsoToHindiAndIpa throws when stroke is not a string', () => {
+  const art = new Articulation({ name: 'consonant', stroke: {} as any });
+  const traj = new Trajectory({ pitches: [new Pitch()] });
+  traj.articulations['0.00'] = art;
+  expect(() => traj.convertCIsoToHindiAndIpa()).toThrow('stroke is not a string');
+});
+
 test('convertCIsoToHindiAndIpa fills missing fields', () => {
   const artStart = new Articulation({ name: 'consonant', stroke: 'ka' });
   const artEnd = new Articulation({ name: 'consonant', stroke: 'ga' });


### PR DESCRIPTION
## Summary
- fix `articulation.test.ts` integrity
- test `convertCIsoToHindiAndIpa` throws when stroke isn't a string

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e9cea2630832e8b0ccf4c896780ee