### PR TITLE
Add trajectory fundamental update test

### DIFF
--- a/src/js/tests/articulation.test.ts
+++ b/src/js/tests/articulation.test.ts
@@ -26,7 +26,8 @@ test('strokeNickname defaults to da for d stroke', () => {
   expect(a.hindi).toBeUndefined();
   expect(a.ipa).toBeUndefined();
   expect(a.engTrans).toBeUndefined();
-  
+});
+
 test('stroke r sets strokeNickname', () => {
   const a = new Articulation({ stroke: 'r' });
   expect(a.strokeNickname).toBe('ra');

--- a/src/js/tests/trajectory.test.ts
+++ b/src/js/tests/trajectory.test.ts
@@ -375,3 +375,17 @@ test('proportionsOfFixedPitches via Piece for all output types', () => {
   expect(piece.proportionsOfFixedPitches({ outputType: 'sargamLetter' })).toEqual({ [sarg1]: 1 / 3, [sarg2]: 2 / 3 });
 });
 
+/* ───────────────────── updateFundamental ───────────────────── */
+
+test('updateFundamental updates all contained pitches', () => {
+  const p1 = new Pitch();
+  const p2 = new Pitch({ swara: 1 });
+  const traj = new Trajectory({ pitches: [p1, p2] });
+
+  traj.updateFundamental(440);
+
+  traj.pitches.forEach(p => {
+    expect(p.fundamental).toBeCloseTo(440);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add unit test to ensure `Trajectory.updateFundamental` updates all pitches
- fix missing closing bracket in `articulation.test.ts` so tests run

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e9ce5e144832e9b9bf3c145bbeddd