### PR TITLE
Add trajectory zero-duration test

### DIFF
--- a/src/js/tests/articulation.test.ts
+++ b/src/js/tests/articulation.test.ts
@@ -26,7 +26,8 @@ test('strokeNickname defaults to da for d stroke', () => {
   expect(a.hindi).toBeUndefined();
   expect(a.ipa).toBeUndefined();
   expect(a.engTrans).toBeUndefined();
-  
+});
+
 test('stroke r sets strokeNickname', () => {
   const a = new Articulation({ stroke: 'r' });
   expect(a.strokeNickname).toBe('ra');

--- a/src/ts/tests/trajectory-zero.test.ts
+++ b/src/ts/tests/trajectory-zero.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from 'vitest';
+import { Trajectory, Pitch } from '../model';
+
+// Ensure zero-duration segments are removed during construction
+
+test('constructor removes zero-duration segments', () => {
+  const p0 = new Pitch();
+  const p1 = new Pitch({ swara: 1 });
+  const p2 = new Pitch({ swara: 2 });
+
+  const traj = new Trajectory({
+    id: 7,
+    pitches: [p0, p1, p2],
+    durArray: [0.3, 0, 0.7]
+  });
+
+  expect(traj.durArray).toEqual([0.3, 0.7]);
+  expect(traj.pitches.length).toBe(2);
+  expect(traj.pitches[0]).toBe(p0);
+  // pitch following the zero-duration segment should be removed
+  expect(traj.pitches[1]).toBe(p1);
+  expect(traj.freqs.length).toBe(2);
+  expect(traj.logFreqs.length).toBe(2);
+});


### PR DESCRIPTION
## Summary
- close brace in articulation test so suite passes
- add new test verifying zero-duration segments are removed when creating a trajectory

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685e9ce3c644832e96e3d4c51d3374d2