### PR TITLE
Add vocal articulation test

### DIFF
--- a/src/js/tests/articulation.test.ts
+++ b/src/js/tests/articulation.test.ts
@@ -26,7 +26,8 @@ test('strokeNickname defaults to da for d stroke', () => {
   expect(a.hindi).toBeUndefined();
   expect(a.ipa).toBeUndefined();
   expect(a.engTrans).toBeUndefined();
-  
+});
+
 test('stroke r sets strokeNickname', () => {
   const a = new Articulation({ stroke: 'r' });
   expect(a.strokeNickname).toBe('ra');

--- a/src/js/tests/trajectory.test.ts
+++ b/src/js/tests/trajectory.test.ts
@@ -56,6 +56,16 @@ test('defaultTrajectory', () => {
   /* … all original id0-id6 assertions … */
 });
 
+test.each([Instrument.Vocal_M, Instrument.Vocal_F])('vocal instrumentation removes pluck (%s)', (inst) => {
+  const t = new Trajectory({
+    instrumentation: inst,
+    articulations: {
+      '0.00': new Articulation({ name: 'pluck', stroke: 'd' })
+    }
+  });
+  expect(t.articulations).toEqual({});
+});
+
 /* ───────────────────────── JSON round-trip ───────────────────────── */
 
 test('trajectory JSON round trip', () => {


### PR DESCRIPTION
## Summary
- fix missing closing brace in articulation test
- add regression test ensuring pluck articulations are removed for vocal instrumentation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e9ce2affc832e97a17f87361af129