### PR TITLE
Add Trajectory constructor error tests

### DIFF
--- a/src/js/tests/articulation.test.ts
+++ b/src/js/tests/articulation.test.ts
@@ -26,7 +26,8 @@ test('strokeNickname defaults to da for d stroke', () => {
   expect(a.hindi).toBeUndefined();
   expect(a.ipa).toBeUndefined();
   expect(a.engTrans).toBeUndefined();
-  
+});
+
 test('stroke r sets strokeNickname', () => {
   const a = new Articulation({ stroke: 'r' });
   expect(a.strokeNickname).toBe('ra');

--- a/src/js/tests/trajectory.test.ts
+++ b/src/js/tests/trajectory.test.ts
@@ -211,6 +211,27 @@ test('invalid slope type throws', () => {
   expect(() => new Trajectory({ slope: 'bad' as any })).toThrow('invalid slope type');
 });
 
+test('non-integer id throws SyntaxError', () => {
+  expect(() => new Trajectory({ id: 1.5 })).toThrow(SyntaxError);
+});
+
+test('invalid pitches array throws SyntaxError', () => {
+  // @ts-expect-error intentionally wrong type
+  expect(() => new Trajectory({ pitches: [new Pitch(), {} as any] })).toThrow(SyntaxError);
+  // @ts-expect-error intentionally not an array
+  expect(() => new Trajectory({ pitches: {} as any })).toThrow(SyntaxError);
+});
+
+test('non-number durTot throws SyntaxError', () => {
+  // @ts-expect-error intentionally wrong type
+  expect(() => new Trajectory({ durTot: 'bad' as any })).toThrow(SyntaxError);
+});
+
+test('non-object articulations throws SyntaxError', () => {
+  // @ts-expect-error intentionally wrong type
+  expect(() => new Trajectory({ articulations: 5 as any })).toThrow(SyntaxError);
+});
+
 test('convertCIsoToHindiAndIpa fills missing fields', () => {
   const artStart = new Articulation({ name: 'consonant', stroke: 'ka' });
   const artEnd = new Articulation({ name: 'consonant', stroke: 'ga' });


### PR DESCRIPTION
## Summary
- fix `articulation.test.ts` test block closure
- add tests ensuring `Trajectory` constructor throws `SyntaxError` on bad arguments

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e9ce1c96c832e985a9ea50cc51bd1