### PR TITLE
Add sloped getter test

### DIFF
--- a/src/js/tests/articulation.test.ts
+++ b/src/js/tests/articulation.test.ts
@@ -26,7 +26,8 @@ test('strokeNickname defaults to da for d stroke', () => {
   expect(a.hindi).toBeUndefined();
   expect(a.ipa).toBeUndefined();
   expect(a.engTrans).toBeUndefined();
-  
+});
+
 test('stroke r sets strokeNickname', () => {
   const a = new Articulation({ stroke: 'r' });
   expect(a.strokeNickname).toBe('ra');

--- a/src/js/tests/trajectory.test.ts
+++ b/src/js/tests/trajectory.test.ts
@@ -375,3 +375,14 @@ test('proportionsOfFixedPitches via Piece for all output types', () => {
   expect(piece.proportionsOfFixedPitches({ outputType: 'sargamLetter' })).toEqual({ [sarg1]: 1 / 3, [sarg2]: 2 / 3 });
 });
 
+test('sloped getter by id and endTime calculation', () => {
+  const ids = Array.from({ length: 14 }, (_, i) => i);
+  ids.forEach(id => {
+    const traj = new Trajectory({ id, durTot: 1 });
+    traj.startTime = 5;
+    const shouldBeSloped = id >= 2 && id <= 5;
+    expect(traj.sloped).toBe(shouldBeSloped);
+    expect(traj.endTime).toBe(6);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add test verifying sloped getter for all trajectory IDs and endTime calculation
- fix articulation tests that were missing closing brace

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e9ce115c0832e83584c3ec7dfcbfb