### PR TITLE
Add test for non-zero Automation start

### DIFF
--- a/src/ts/tests/automation.test.ts
+++ b/src/ts/tests/automation.test.ts
@@ -163,3 +163,14 @@ test('partition with zero-length segment', () => {
     expect(env3[i]).toBeCloseTo(expected3[i]);
   }
 });
+
+
+test('valueAtX throws when x before first value', () => {
+  const auto = new Automation({
+    values: [
+      { normTime: 0.2, value: 0.5 },
+      { normTime: 1, value: 1 }
+    ]
+  });
+  expect(() => auto.valueAtX(0.1)).toThrow(SyntaxError);
+});


### PR DESCRIPTION
## Summary
- add a test checking `valueAtX` throws when queried before the first automation value

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_685ebbcf70d8832e9336d4408c6c587f