### PR TITLE
Add raga ratio out-of-range test

### DIFF
--- a/src/ts/tests/raga-model.test.ts
+++ b/src/ts/tests/raga-model.test.ts
@@ -71,3 +71,9 @@ test('model raga core utilities', () => {
   ];
   expect(r.swaraObjects).toEqual(objs);
 });
+
+test('ratioIdxToTuningTuple out of range', () => {
+  const r = new Raga();
+  const invalidIdx = r.ruleSetNumPitches; // index larger than highest valid
+  expect(r.ratioIdxToTuningTuple(invalidIdx)).toBeUndefined();
+});


### PR DESCRIPTION
## Summary
- verify that `ratioIdxToTuningTuple` returns `undefined` when index exceeds pitch count

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ebbc56abc832e859b8155ab904a7e