### PR TITLE
Add test for Trajectory articulation key

### DIFF
--- a/src/ts/tests/trajectory-articulation-key.test.ts
+++ b/src/ts/tests/trajectory-articulation-key.test.ts
@@ -1,0 +1,10 @@
+import { expect, test } from 'vitest';
+import { Trajectory, Articulation } from '../model';
+
+test('numeric articulation keys are normalized to decimals', () => {
+  const art = new Articulation({ name: 'pluck', stroke: 'd' });
+  const traj = new Trajectory({ articulations: { 0: art } });
+
+  expect(traj.articulations['0.00']).toBeInstanceOf(Articulation);
+  expect(traj.articulations['0']).toBeUndefined();
+});


### PR DESCRIPTION
## Summary
- add vitest to ensure numeric articulation keys are normalized to '0.00'

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ebc17289c832eb12b9d899c8d4df5