### PR TITLE
Add trajectory log frequency tests

### DIFF
--- a/src/ts/tests/trajectory-logfreq.test.ts
+++ b/src/ts/tests/trajectory-logfreq.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from 'vitest';
+import { Trajectory, Pitch } from '../model';
+
+// minLogFreq and maxLogFreq should reflect the range of log frequencies
+
+test('minLogFreq and maxLogFreq compute from pitches', () => {
+  const c4 = Pitch.fromPitchNumber(0); // C4 ~261.63 Hz
+  const g4 = Pitch.fromPitchNumber(7); // G4 ~392 Hz
+  const traj = new Trajectory({ pitches: [c4, g4] });
+
+  const minFreq = Math.min(c4.frequency, g4.frequency);
+  const maxFreq = Math.max(c4.frequency, g4.frequency);
+  expect(traj.minLogFreq).toBeCloseTo(Math.log2(minFreq));
+  expect(traj.maxLogFreq).toBeCloseTo(Math.log2(maxFreq));
+});


### PR DESCRIPTION
## Summary
- add test covering minLogFreq/maxLogFreq logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ebc18a95c832e8b0555b85d5bb45b