### PR TITLE
Add phrase duration scaling test

### DIFF
--- a/src/js/tests/phrase.test.ts
+++ b/src/js/tests/phrase.test.ts
@@ -328,3 +328,18 @@ test('constructor pads grids to instrumentation length', () => {
   expect(phrase.trajectoryGrid[1]).toEqual([]);
   expect(phrase.chikariGrid[1]).toEqual({});
 });
+
+test('constructor scales trajectories when durTot and durArray passed', () => {
+  const t1 = new Trajectory({ durTot: 1, pitches: [new Pitch()] });
+  const t2 = new Trajectory({ durTot: 1, pitches: [new Pitch({ swara: 'r' })] });
+  const durArray = [0.2, 0.8];
+  const phrase = new Phrase({
+    trajectories: [t1, t2],
+    durTot: 4,
+    durArray,
+  });
+  expect(phrase.durTot).toBeCloseTo(4);
+  expect(phrase.durArray).toEqual(durArray);
+  expect(t1.durTot).toBeCloseTo(0.8);
+  expect(t2.durTot).toBeCloseTo(3.2);
+});


### PR DESCRIPTION
## Summary
- test scaling when `durTot` and `durArray` differ from trajectory totals

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685ebe898bf4832e89c0d8fd004cb16e