### PR TITLE
Add test for nonzero trajectory id in toNoteViewPhrase

### DIFF
--- a/src/js/tests/phrase.test.ts
+++ b/src/js/tests/phrase.test.ts
@@ -180,6 +180,18 @@ test('toNoteViewPhrase includes pitches from id 0 trajectory with articulations'
   expect(nv.pitches[0]).toBe(pitch);
 });
 
+test('toNoteViewPhrase includes pitches from nonzero id trajectory with no articulations', () => {
+  const pitch = new Pitch({ swara: 'ma' });
+  const traj = new Trajectory({
+    id: 2,
+    pitches: [pitch],
+    articulations: {},
+  });
+  const phrase = new Phrase({ trajectories: [traj] });
+  const nv = phrase.toNoteViewPhrase();
+  expect(nv.pitches).toContain(pitch);
+});
+
 
 test('fromJSON reconstructs trajectory and chikari grids', () => {
   const t1 = new Trajectory({ num: 0, pitches: [new Pitch()] });


### PR DESCRIPTION
## Summary
- add missing test for toNoteViewPhrase when trajectory id is not 0 and has no articulations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ebe8f545c832e97521cfe44a8158d