### PR TITLE
Add test for Phrase.fromJSON fallbacks

### DIFF
--- a/src/js/tests/phrase.test.ts
+++ b/src/js/tests/phrase.test.ts
@@ -328,3 +328,16 @@ test('constructor pads grids to instrumentation length', () => {
   expect(phrase.trajectoryGrid[1]).toEqual([]);
   expect(phrase.chikariGrid[1]).toEqual({});
 });
+
+test('fromJSON uses fallbacks for missing grids', () => {
+  const obj = {
+    trajectories: [],
+    instrumentation: ['Sitar', 'Violin'],
+    startTime: 0,
+  };
+  const phrase = Phrase.fromJSON(obj);
+  expect(phrase.trajectoryGrid.length).toBe(obj.instrumentation.length);
+  expect(phrase.chikariGrid.length).toBe(obj.instrumentation.length);
+  phrase.trajectoryGrid.forEach(row => expect(row).toEqual([]));
+  phrase.chikariGrid.forEach(col => expect(col).toEqual({}));
+});


### PR DESCRIPTION
## Summary
- test that Phrase.fromJSON populates empty grids when trajectoryGrid and chikaris are omitted

## Testing
- `npx vitest run --silent`

------
https://chatgpt.com/codex/tasks/task_e_685ebe8ec330832ea3466733861f105a