### PR TITLE
Add phrase Bol Alap initialization test

### DIFF
--- a/src/ts/model/phrase.ts
+++ b/src/ts/model/phrase.ts
@@ -8,7 +8,7 @@ import { v4 as uuidv4 } from 'uuid';
 import  findLastIndex  from 'lodash/findLastIndex';
 import { getStarts } from '@/ts/utils';
 
-const initPhraseCategorization = (): PhraseCatType => {
+export const initPhraseCategorization = (): PhraseCatType => {
   return {
     "Phrase": {
       "Mohra": false,

--- a/src/ts/tests/phrase-bolalap.test.ts
+++ b/src/ts/tests/phrase-bolalap.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from 'vitest';
+import { Phrase, initPhraseCategorization } from '../model';
+
+// Ensure missing "Bol Alap" property gets initialized to false
+
+test('constructor fills missing Bol Alap categorization', () => {
+  const custom = initPhraseCategorization();
+  // Remove the property so constructor must add it
+  delete custom.Elaboration['Bol Alap'];
+
+  const phrase = new Phrase({ categorizationGrid: [custom] });
+
+  expect(phrase.categorizationGrid[0].Elaboration['Bol Alap']).toBe(false);
+});
+


### PR DESCRIPTION
## Summary
- export `initPhraseCategorization` from the phrase model
- test that a missing `Bol Alap` flag is initialized to `false`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685ebe8cbb1c832eb4ecbb05956d4f5f