### PR TITLE
Add Python test for trajectory articulation key normalization

### DIFF
--- a/python/api/classes/__init__.py
+++ b/python/api/classes/__init__.py
@@ -1,0 +1,6 @@
+from .pitch import Pitch
+from .raga import Raga
+from .articulation import Articulation
+from .trajectory import Trajectory
+
+__all__ = ["Pitch", "Raga", "Articulation", "Trajectory"]

--- a/python/api/classes/articulation.py
+++ b/python/api/classes/articulation.py
@@ -1,0 +1,43 @@
+from typing import Optional, TypedDict
+import humps
+
+class ArticulationOptions(TypedDict, total=False):
+    name: str
+    stroke: str
+    hindi: str
+    ipa: str
+    eng_trans: str
+    stroke_nickname: str
+
+class Articulation:
+    def __init__(self, options: Optional[ArticulationOptions] = None):
+        if options is None:
+            options = {}
+        else:
+            options = humps.decamelize(options)
+        self.name = options.get('name', 'pluck')
+        stroke = options.get('stroke')
+        hindi = options.get('hindi')
+        ipa = options.get('ipa')
+        eng_trans = options.get('eng_trans')
+        stroke_nickname = options.get('stroke_nickname')
+
+        if stroke is not None:
+            self.stroke = stroke
+        if hindi is not None:
+            self.hindi = hindi
+        if ipa is not None:
+            self.ipa = ipa
+        if eng_trans is not None:
+            self.eng_trans = eng_trans
+        if stroke_nickname is not None:
+            self.stroke_nickname = stroke_nickname
+
+        if getattr(self, 'stroke', None) == 'd' and stroke_nickname is None:
+            self.stroke_nickname = 'da'
+        elif getattr(self, 'stroke', None) == 'r' and stroke_nickname is None:
+            self.stroke_nickname = 'ra'
+
+    @staticmethod
+    def from_json(obj: dict) -> "Articulation":
+        return Articulation(obj)

--- a/python/api/classes/trajectory.py
+++ b/python/api/classes/trajectory.py
@@ -1,0 +1,42 @@
+from typing import Optional, Dict
+import humps
+from .pitch import Pitch
+from .articulation import Articulation
+
+ArtDict = Dict[str, Articulation]
+
+class TrajectoryOptions(dict):
+    pass
+
+class Trajectory:
+    def __init__(self, options: Optional[TrajectoryOptions] = None):
+        if options is None:
+            options = {}
+        else:
+            options = humps.decamelize(options)
+
+        self.id = options.get('id', 0)
+        self.pitches = options.get('pitches', [Pitch()])
+        self.dur_tot = options.get('dur_tot', 1.0)
+        self.dur_array = options.get('dur_array')
+        self.slope = options.get('slope', 2)
+
+        arts = options.get('articulations')
+        if arts is None:
+            self.articulations: ArtDict = {'0.00': Articulation({'name': 'pluck', 'stroke': 'd'})}
+        else:
+            self.articulations = {}
+            for key, value in arts.items():
+                if isinstance(key, (int, float)) or (isinstance(key, str) and key.replace('.', '', 1).isdigit()):
+                    k = f"{float(key):.2f}"
+                else:
+                    k = str(key)
+                self.articulations[k] = value
+        # normalize any numeric string keys left as integers like '0'
+        for key in list(self.articulations.keys()):
+            if isinstance(key, str) and key.isdigit():
+                val = self.articulations.pop(key)
+                self.articulations[f"{float(key):.2f}"] = val
+
+        self.num = options.get('num')
+        self.name = options.get('name')

--- a/python/api/tests/trajectory_articulation_key_test.py
+++ b/python/api/tests/trajectory_articulation_key_test.py
@@ -1,0 +1,9 @@
+from python.api.classes import Trajectory, Articulation
+
+
+def test_numeric_articulation_keys_are_normalized():
+    art = Articulation({"name": "pluck", "stroke": "d"})
+    traj = Trajectory({"articulations": {0: art}})
+
+    assert isinstance(traj.articulations.get("0.00"), Articulation)
+    assert "0" not in traj.articulations


### PR DESCRIPTION
## Summary
- implement Python versions of `Articulation` and `Trajectory`
- expose new classes from `python.api.classes`
- add unit test ensuring articulation keys like `0` are normalized to decimal strings

## Testing
- `PYTHONPATH=. pytest -q python/api/tests/trajectory_articulation_key_test.py -s`
- `PYTHONPATH=. pytest -q python/api/tests -s`

------
https://chatgpt.com/codex/tasks/task_e_685ed0192bc0832eb96bfa9ec6c745f9