### PR TITLE
Add Python trajectory id6 test

### DIFF
--- a/humps/__init__.py
+++ b/humps/__init__.py
@@ -1,0 +1,16 @@
+import re
+from typing import Any
+
+def decamelize(obj: Any) -> Any:
+    """Convert camelCase keys in a dict to snake_case recursively."""
+    if isinstance(obj, dict):
+        new = {}
+        for k, v in obj.items():
+            s1 = re.sub(r"(.)([A-Z][a-z]+)", r"\1_\2", k)
+            s2 = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", s1).lower()
+            new[s2] = decamelize(v)
+        return new
+    elif isinstance(obj, list):
+        return [decamelize(i) for i in obj]
+    else:
+        return obj

--- a/python/api/classes/trajectory.py
+++ b/python/api/classes/trajectory.py
@@ -1,0 +1,46 @@
+from typing import List, Optional, TypedDict
+import humps
+from .pitch import Pitch
+
+class TrajectoryOptionsType(TypedDict, total=False):
+    id: int
+    pitches: List[Pitch]
+    dur_array: List[float]
+
+class Trajectory:
+    def __init__(self, options: Optional[TrajectoryOptionsType] = None):
+        if options is None:
+            options = {}
+        else:
+            options = humps.decamelize(options)
+        self.id = options.get('id', 0)
+        self.pitches: List[Pitch] = options.get('pitches', [])
+        self.dur_array: Optional[List[float]] = options.get('dur_array')
+        self.log_freqs = [p.log_freq for p in self.pitches]
+        if self.id == 6 and self.dur_array is None and len(self.pitches) >= 2:
+            self.dur_array = [1/(len(self.pitches)-1)] * (len(self.pitches)-1)
+
+    def id1(self, x: float, log_freqs: Optional[List[float]] = None) -> float:
+        if log_freqs is None:
+            log_freqs = self.log_freqs[:2]
+        start, end = log_freqs[0], log_freqs[1]
+        lf = start + (end - start) * x
+        return 2 ** lf
+
+    def id6(self, x: float, lf: Optional[List[float]] = None, da: Optional[List[float]] = None) -> float:
+        log_freqs = self.log_freqs if lf is None else lf
+        dur_array = self.dur_array if da is None else da
+        if dur_array is None:
+            dur_array = [1/(len(log_freqs)-1)] * (len(log_freqs)-1)
+        starts = [0]
+        for d in dur_array[:-1]:
+            starts.append(starts[-1] + d)
+        index = -1
+        for i, s in enumerate(starts):
+            if x >= s:
+                index = i
+        if index == -1 or index >= len(log_freqs)-1:
+            print('invalid x', x, 'index', index)
+            raise ValueError('x out of bounds')
+        inner_x = (x - starts[index]) / dur_array[index]
+        return self.id1(inner_x, log_freqs[index:index+2])

--- a/python/api/tests/trajectory_id6_test.py
+++ b/python/api/tests/trajectory_id6_test.py
@@ -1,0 +1,24 @@
+from python.api.classes.trajectory import Trajectory
+from python.api.classes.pitch import Pitch
+import pytest
+
+
+def test_id6_default_durarray_and_error_logging(capfd):
+    p0 = Pitch()
+    p1 = Pitch({'swara': 1})
+    p2 = Pitch({'swara': 2})
+    pitches = [p0, p1, p2]
+
+    traj = Trajectory({'id': 6, 'pitches': pitches, 'durArray': None})
+
+    expected = [1 / (len(pitches) - 1)] * (len(pitches) - 1)
+    assert traj.dur_array == expected
+
+    freq = traj.id6(0.5)
+    assert isinstance(freq, float)
+    assert freq > 0
+
+    with pytest.raises(ValueError):
+        traj.id6(-0.1)
+    out, _ = capfd.readouterr()
+    assert 'invalid x' in out


### PR DESCRIPTION
## Summary
- implement minimal `Trajectory` class in python
- add decamelize helper for tests
- add pytest verifying id6 default durations and error logging

## Testing
- `PYTHONPATH=. pytest -q python/api/tests`

------
https://chatgpt.com/codex/tasks/task_e_685ed01a9b3c832ebaa561219aab224c