### PR TITLE
Translate piece-durations.test to Python

### DIFF
--- a/python/api/classes/phrase.py
+++ b/python/api/classes/phrase.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+from typing import List, Optional
+from .trajectory import Trajectory
+
+class Phrase:
+    def __init__(self, trajectories: Optional[List[Trajectory]] = None, raga=None, durTot: Optional[float] = None):
+        self.trajectories: List[Trajectory] = trajectories or []
+        self.raga = raga
+        self.durTot = durTot
+        self.durArray: List[float] = []
+        if self.trajectories:
+            self.durTotFromTrajectories()
+            self.durArrayFromTrajectories()
+        else:
+            if self.durTot is None:
+                self.durTot = 1
+
+    def durTotFromTrajectories(self) -> None:
+        self.durTot = sum(t.durTot for t in self.trajectories)
+
+    def durArrayFromTrajectories(self) -> None:
+        self.durTotFromTrajectories()
+        if self.durTot == 0:
+            self.durArray = [0 for _ in self.trajectories]
+        else:
+            self.durArray = [t.durTot / self.durTot for t in self.trajectories]
+
+    def reset(self) -> None:
+        self.durArrayFromTrajectories()

--- a/python/api/classes/piece.py
+++ b/python/api/classes/piece.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+from typing import List, Optional
+import math
+
+from .phrase import Phrase
+from .trajectory import Trajectory
+from .raga import Raga
+from enum import Enum
+
+class Instrument(Enum):
+    Sitar = "Sitar"
+
+class Piece:
+    def __init__(self,
+                 phraseGrid: Optional[List[List[Phrase]]] = None,
+                 instrumentation: Optional[List[Instrument]] = None,
+                 raga: Optional[Raga] = None):
+        self.instrumentation = instrumentation or [Instrument.Sitar]
+        self.raga = raga or Raga()
+        if phraseGrid is not None:
+            self.phraseGrid = phraseGrid
+        else:
+            self.phraseGrid = [[] for _ in self.instrumentation]
+        self.durTot: Optional[float] = None
+        self.durArrayGrid: List[List[float]] = [[] for _ in self.instrumentation]
+
+    def durTotFromPhrases(self) -> None:
+        durTots = []
+        for phrases in self.phraseGrid:
+            durTot = sum(p.durTot for p in phrases)
+            durTots.append(durTot)
+        maxDurTot = max(durTots) if durTots else 0
+        self.durTot = maxDurTot
+        for idx, d in enumerate(durTots):
+            if d != maxDurTot:
+                extra = maxDurTot - d
+                extra_silent = Trajectory(id=12, durTot=extra)
+                if len(self.phraseGrid[idx]) == 0:
+                    phr = Phrase(trajectories=[extra_silent], durTot=extra, raga=self.raga)
+                    self.phraseGrid[idx].append(phr)
+                    phr.reset()
+                else:
+                    lastPhrase = self.phraseGrid[idx][-1]
+                    lastPhrase.trajectories.append(extra_silent)
+                    lastPhrase.reset()
+
+    def durArrayFromPhrases(self) -> None:
+        self.durTotFromPhrases()
+        for idx, phrases in enumerate(self.phraseGrid):
+            arr = []
+            for p in phrases:
+                if p.durTot is None:
+                    raise ValueError('p.durTot is undefined')
+                elif math.isnan(p.durTot):
+                    removes = [t for t in p.trajectories if math.isnan(t.durTot)]
+                    for r in removes:
+                        p.trajectories.remove(r)
+                    p.durTot = sum(t.durTot for t in p.trajectories)
+                arr.append(p.durTot / self.durTot if self.durTot else 0)
+            self.durArrayGrid[idx] = arr

--- a/python/api/classes/trajectory.py
+++ b/python/api/classes/trajectory.py
@@ -1,0 +1,7 @@
+from dataclasses import dataclass
+from typing import Optional
+
+@dataclass
+class Trajectory:
+    durTot: float = 1.0
+    id: int = 0

--- a/python/api/tests/conftest.py
+++ b/python/api/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+import os
+
+# Ensure project root is in PYTHONPATH for imports
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)

--- a/python/api/tests/piece_durations_test.py
+++ b/python/api/tests/piece_durations_test.py
@@ -1,0 +1,47 @@
+from python.api.classes.piece import Piece, Instrument
+from python.api.classes.phrase import Phrase
+from python.api.classes.trajectory import Trajectory
+from python.api.classes.raga import Raga
+import pytest
+import math
+
+# Helper to build a piece with two tracks, second empty
+
+def build_piece_with_empty_track():
+    raga = Raga()
+    t1 = Trajectory(durTot=1)
+    p1 = Phrase(trajectories=[t1], raga=raga)
+    return Piece(
+        phraseGrid=[[p1], []],
+        instrumentation=[Instrument.Sitar, Instrument.Sitar],
+        raga=raga,
+    )
+
+
+def test_durtotfromphrases_creates_silent_phrase_for_empty_track():
+    piece = build_piece_with_empty_track()
+    piece.durTotFromPhrases()
+    assert len(piece.phraseGrid[1]) == 1
+    silent_traj = piece.phraseGrid[1][0].trajectories[0]
+    assert silent_traj.id == 12
+    assert silent_traj.durTot == pytest.approx(1)
+
+# Helper for NaN trajectory cleanup
+
+def build_piece_with_nan_traj():
+    raga = Raga()
+    piece = Piece(raga=raga, instrumentation=[Instrument.Sitar])
+    good = Trajectory(durTot=1)
+    bad = Trajectory(durTot=math.nan)
+    phrase = Phrase(trajectories=[good, bad], raga=raga)
+    phrase.durTotFromTrajectories()
+    piece.phraseGrid[0].append(phrase)
+    return piece, phrase
+
+
+def test_durarrayfromphrases_removes_nan_trajectories():
+    piece, phrase = build_piece_with_nan_traj()
+    assert math.isnan(phrase.durTot)
+    piece.durArrayFromPhrases()
+    assert len(phrase.trajectories) == 1
+    assert phrase.durTot == pytest.approx(1)


### PR DESCRIPTION
## Summary
- add minimal Python models for `Piece`, `Phrase`, and `Trajectory`
- create pytest for piece duration logic
- ensure tests import correctly via `conftest`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ed01341ec832e8e8473bc6bfd5f1f