### PR TITLE
Port raga tests from TypeScript

### DIFF
--- a/python/api/classes/pitch.py
+++ b/python/api/classes/pitch.py
@@ -1,5 +1,18 @@
 from typing import List, Dict, TypedDict, Optional, Union
-import humps
+try:
+    import humps
+    decamelize = humps.decamelize  # type: ignore
+except Exception:  # fallback if humps is missing or has no decamelize
+    import re
+
+    def decamelize(obj):
+        if isinstance(obj, dict):
+            out = {}
+            for k, v in obj.items():
+                s = re.sub(r'(?<!^)(?=[A-Z])', '_', k).lower()
+                out[s] = decamelize(v) if isinstance(v, dict) else v
+            return out
+        return obj
 import math
 
 # this should all be implemented in snake_case, even though the TypeScript 
@@ -20,7 +33,7 @@ class Pitch:
             options = {}
         else:
             # convert camelCase incoming keys to snake_case
-            options = humps.decamelize(options)
+            options = decamelize(options)
 
         self.log_offset = options.get('log_offset', 0.0)
 

--- a/python/api/classes/raga.py
+++ b/python/api/classes/raga.py
@@ -1,330 +1,353 @@
-from typing import Optional, TypedDict
-import humps
+from __future__ import annotations
+from typing import Optional, TypedDict, Dict, List, Tuple, Union
 import math
+import copy
+try:
+    import humps
+    decamelize = humps.decamelize  # type: ignore
+except Exception:
+    import re
+
+    def decamelize(obj):
+        if isinstance(obj, dict):
+            out = {}
+            for k, v in obj.items():
+                s = re.sub(r'(?<!^)(?=[A-Z])', '_', k).lower()
+                out[s] = decamelize(v) if isinstance(v, dict) else v
+            return out
+        return obj
+
 from .pitch import Pitch
 
+BoolObj = Dict[str, bool]
+RuleSetType = Dict[str, Union[bool, BoolObj]]
+NumObj = Dict[str, float]
+TuningType = Dict[str, Union[float, NumObj]]
 
-BoolObj = dict[str, bool]   
-RuleSetType = dict[str, bool | BoolObj]
-NumObj = dict[str, float]
-TuningType = dict[str, float | NumObj]
+# Default Yaman rule set
+yaman_rule_set: RuleSetType = {
+    'sa': True,
+    're': {'lowered': False, 'raised': True},
+    'ga': {'lowered': False, 'raised': True},
+    'ma': {'lowered': False, 'raised': True},
+    'pa': True,
+    'dha': {'lowered': False, 'raised': True},
+    'ni': {'lowered': False, 'raised': True},
+}
 
-
-yaman_rule_set = {
-	'sa': True,
-	're': {
-		'lowered': False,
-		'raised': True
-	},
-	'ga': {
-		'lowered': False,
-		'raised': True
-	},
-	'ma': {
-		'lowered': False,
-		'raised': True
-	},
-	'pa': True,
-	'dha': {
-		'lowered': False,
-		'raised': True
-	},
-	'ni': {
-		'lowered': False,
-		'raised': True
-	}
+# 12-TET tuning ratios
+et_tuning: TuningType = {
+    'sa': 2 ** (0 / 12),
+    're': {'lowered': 2 ** (1 / 12), 'raised': 2 ** (2 / 12)},
+    'ga': {'lowered': 2 ** (3 / 12), 'raised': 2 ** (4 / 12)},
+    'ma': {'lowered': 2 ** (5 / 12), 'raised': 2 ** (6 / 12)},
+    'pa': 2 ** (7 / 12),
+    'dha': {'lowered': 2 ** (8 / 12), 'raised': 2 ** (9 / 12)},
+    'ni': {'lowered': 2 ** (10 / 12), 'raised': 2 ** (11 / 12)},
 }
 
 class RagaOptionsType(TypedDict, total=False):
-	name: str
-	fundamental: float
-	rule_set: RuleSetType
-	tuning: TuningType
-	ratios: list[float]
+    name: str
+    fundamental: float
+    rule_set: RuleSetType
+    tuning: TuningType
+    ratios: List[float]
 
-class Raga():
-	def __init__(self, options: Optional[RagaOptionsType] = None):
-		if options is None:
-			options = {}
-		else:
-			options = humps.decamelize(options)
-		self.name = options.get('name', 'Yaman')
-		self.fundamental = options.get('fundamental', 261.63)
-		self.rule_set = options.get('rule_set', yaman_rule_set)
-		self.ratios = None
-		self.tuning: TuningType = {
-			'sa': 2 ** (0 / 12),
-			're': {
-				'lowered': 2 ** (1 / 12),
-				'raised': 2 ** (2 / 12)
-			},
-			'ga': {
-				'lowered': 2 ** (3 / 12),
-				'raised': 2 ** (4 / 12)
-			},
-			'ma': {
-				'lowered': 2 ** (5 / 12),
-				'raised': 2 ** (6 / 12)
-			},
-			'pa': 2 ** (7 / 12),
-			'dha': {
-				'lowered': 2 ** (8 / 12),
-				'raised': 2 ** (9 / 12)
-			},
-			'ni': {
-				'lowered': 2 ** (10 / 12),
-				'raised': 2 ** (11 / 12)
-			}
-		}
-		c1 = options.get('ratios') is None
-		c2 = (not c1) and options.get('ratios').length != self.rule_set_num_pitches
-		if c1 or c2:
-			self.ratios = self.set_ratios(self.rule_set)
-		else:
-			self.ratios = options.get('ratios')
-			
-	@property
-	def rule_set_num_pitches(self):
-		num_pitches = 0
-		for key in self.rule_set:
-			if type(self.rule_set[key]) == bool:
-				if self.rule_set[key]:
-					num_pitches += 1
-			else:
-				if self.rule_set[key]['lowered']:
-					num_pitches += 1
-				if self.rule_set[key]['raised']:
-					num_pitches += 1
-		return num_pitches
-	
-	def set_ratios(self, rule_set: RuleSetType):
-		sargam = rule_set.keys()
-		ratios: list[float] = []
-		for s in sargam:
-			if type(self.tuning[s]) == float and rule_set[s]:
-				ratios.append(self.tuning[s])
-			else:
-				rs: BoolObj = rule_set[s]
-				tuning: NumObj = self.tuning[s]
-				if rs['lowered']:
-					ratios.append(tuning['lowered'])
-				if rs['raised']:
-					ratios.append(tuning['raised'])
-		return ratios
+class Raga:
+    def __init__(self, options: Optional[RagaOptionsType] = None) -> None:
+        opts = decamelize(options or {})
+        self.name: str = opts.get('name', 'Yaman')
+        self.fundamental: float = opts.get('fundamental', 261.63)
+        self.rule_set: RuleSetType = opts.get('rule_set', yaman_rule_set)
+        self.tuning: TuningType = copy.deepcopy(opts.get('tuning', et_tuning))
 
-	@property
-	def sargam_letters(self):
-		init_sargam = ['sa', 're', 'ga', 'ma', 'pa', 'dha', 'ni']
-		sl = []
-		for s in init_sargam:
-			if isinstance(self.rule_set[s], dict):
-				rule_set = self.rule_set[s]
-				if rule_set.get('lowered'):
-					sl.append(s[0])
-				if rule_set.get('raised'):
-					sl.append(s[0].upper())
-			elif self.rule_set[s]:
-				sl.append(s[0].upper())
-		return sl
-	
-	#helper method needed for other methods
-	def chroma_to_scale_degree(self, chroma):
-		scale_degree = 0
-		raised = True
+        ratios_opt = opts.get('ratios')
+        if ratios_opt is None or len(ratios_opt) != self.rule_set_num_pitches:
+            self.ratios: List[float] = self.set_ratios(self.rule_set)
+        else:
+            self.ratios = list(ratios_opt)
 
-		if chroma == 0:
-			scale_degree = 0
-			raised = True
-		elif chroma == 1:
-			scale_degree = 1
-			raised = False
-		elif chroma == 2:
-			scale_degree = 1
-			raised = True
-		elif chroma == 3:
-			scale_degree = 2
-			raised = False
-		elif chroma == 4:
-			scale_degree = 2
-			raised = True
-		elif chroma == 5:
-			scale_degree = 3
-			raised = False
-		elif chroma == 6:
-			scale_degree = 3
-			raised = True
-		elif chroma == 7:
-			scale_degree = 4
-			raised = True
-		elif chroma == 8:
-			scale_degree = 5
-			raised = False
-		elif chroma == 9:
-			scale_degree = 5
-			raised = True
-		elif chroma == 10:
-			scale_degree = 6
-			raised = False
-		elif chroma == 11:
-			scale_degree = 6
-			raised = True
-		return scale_degree, raised
+        # update tuning values from ratios
+        for idx, ratio in enumerate(self.ratios):
+            swara, variant = self.ratio_idx_to_tuning_tuple(idx)
+            if swara in ('sa', 'pa'):
+                self.tuning[swara] = ratio
+            else:
+                if not isinstance(self.tuning[swara], dict):
+                    self.tuning[swara] = {'lowered': 0.0, 'raised': 0.0}
+                self.tuning[swara][variant] = ratio
 
-	def pitch_number_to_sargam_letters(self, pitch_number):
-		oct = int(pitch_number / 12)
-		out = None
-		chroma = pitch_number % 12
-		while chroma < 0:
-			chroma += 12
-		scale_degree, raised = self.chroma_to_scale_degree(chroma)
-		sargam = ['sa', 're', 'ga', 'ma', 'pa', 'dha', 'ni'][scale_degree]
-		if isinstance(self.rule_set[sargam], bool):
-			if self.rule_set[sargam]:
-				out = sargam[0].upper()
-		else:
-			rule_set = self.rule_set[sargam]
-			if rule_set['raised' if raised else 'lowered']:
-				out = sargam[0].upper() if raised else sargam[0]
-		return out
+    # ------------------------------------------------------------------
+    @property
+    def sargam_letters(self) -> List[str]:
+        init = ['sa', 're', 'ga', 'ma', 'pa', 'dha', 'ni']
+        out: List[str] = []
+        for s in init:
+            val = self.rule_set[s]
+            if isinstance(val, dict):
+                if val.get('lowered'):
+                    out.append(s[0])
+                if val.get('raised'):
+                    out.append(s[0].upper())
+            elif val:
+                out.append(s[0].upper())
+        return out
 
-	def get_pitch_numbers(self, low, high):
-		pitch_numbers = []
-		for i in range(low,high+1):
-			oct = int(i / 12)
-			chroma = i % 12
-			while chroma < 0:
-				chroma += 12
-			scale_degree, raised = self.chroma_to_scale_degree(chroma)
-			sargam = ['sa', 're', 'ga', 'ma', 'pa', 'dha', 'ni'][scale_degree]
-			if isinstance(self.rule_set[sargam], bool):
-				if self.rule_set[sargam]:
-					pitch_numbers.append(i)
-			else:
-				rule_set = self.rule_set[sargam]
-				if rule_set['raised' if raised else 'lowered']:
-					pitch_numbers.append(i)
-		return pitch_numbers
+    @property
+    def solfege_strings(self) -> List[str]:
+        pl = self.get_pitches(low=self.fundamental, high=self.fundamental * 1.999)
+        return [p.solfege_letter for p in pl]
 
-	def pitch_number_to_scale_number(self, pitch_number):
-		oct = pitch_number // 12
-		chroma = pitch_number % 12
-		while chroma < 0:
-			chroma += 12
-		main_oct = self.get_pitch_numbers(0, 11)
-		index = main_oct.index(chroma)
-		if index == -1:
-			raise ValueError('pitchNumberToScaleNumber: pitchNumber not in raga')
-		return index + oct * len(main_oct)
+    @property
+    def pc_strings(self) -> List[str]:
+        pl = self.get_pitches(low=self.fundamental, high=self.fundamental * 1.999)
+        return [str(p.chroma) for p in pl]
 
-	def scale_number_to_pitch_number(self, scale_number):
-		main_oct = self.get_pitch_numbers(0, 11)
-		oct = scale_number // len(main_oct)
-		while scale_number < 0:
-			scale_number += len(main_oct)
-		chroma = main_oct[scale_number % len(main_oct)]
-		return chroma + oct * 12
+    @property
+    def western_pitch_strings(self) -> List[str]:
+        pl = self.get_pitches(low=self.fundamental, high=self.fundamental * 1.999)
+        return [p.western_pitch for p in pl]
 
-	def scale_number_to_sargam_letter(self, scale_number):
-		pitch_number = self.scale_number_to_pitch_number(scale_number)
-		return self.pitch_number_to_sargam_letters(pitch_number)
+    @property
+    def rule_set_num_pitches(self) -> int:
+        count = 0
+        for key, val in self.rule_set.items():
+            if isinstance(val, bool):
+                if val:
+                    count += 1
+            else:
+                if val.get('lowered'):
+                    count += 1
+                if val.get('raised'):
+                    count += 1
+        return count
 
-	def get_pitches(self, low=100, high=800):
-		sargam = list(self.rule_set.keys())
-		pitches = []
-		for s in sargam:
-			if isinstance(self.rule_set[s], bool) and self.rule_set[s]:
-				freq = self.tuning[s] * self.fundamental
-				octs_below = math.ceil(math.log2(low / freq))
-				octs_above = math.floor(math.log2(high / freq))
-				for i in range(octs_below, octs_above + 1):
-					pitches.append(Pitch(options={'swara': s, 'oct': i, 
-						'fundamental': self.fundamental, 'ratios': self.stratified_ratios}))
-			else:
-				if self.rule_set[s]['lowered']:
-					freq = self.tuning[s]['lowered'] * self.fundamental
-					octs_below = math.ceil(math.log2(low / freq))
-					octs_above = math.floor(math.log2(high / freq))
-					for i in range(octs_below, octs_above + 1):
-						pitches.append(Pitch(options={'swara': s, 'oct': i, 'raised': False, 
-							'fundamental': self.fundamental, 'ratios': self.stratified_ratios}))
-				elif self.rule_set[s]['raised']:
-					freq = self.tuning[s]['raised'] * self.fundamental
-					octs_below = math.ceil(math.log2(low / freq))
-					octs_above = math.floor(math.log2(high / freq))
-					for i in range(octs_below, octs_above + 1):
-						pitches.append(Pitch(options={'swara': s, 'oct': i, 'raised': True,  
-							'fundamental': self.fundamental, 'ratios': self.stratified_ratios}))
-		pitches.sort(key=lambda x: x.frequency)
-		return pitches
+    # ------------------------------------------------------------------
+    def pitch_number_to_sargam_letter(self, pitch_number: int) -> Optional[str]:
+        chroma = pitch_number % 12
+        while chroma < 0:
+            chroma += 12
+        scale_degree, raised = Pitch.chroma_to_scale_degree(chroma)
+        swara = ['sa', 're', 'ga', 'ma', 'pa', 'dha', 'ni'][scale_degree]
+        val = self.rule_set[swara]
+        if isinstance(val, bool):
+            if val:
+                return swara[0].upper()
+            return None
+        else:
+            if val['raised' if raised else 'lowered']:
+                return swara[0].upper() if raised else swara[0]
+            return None
 
-	@property
-	def stratified_ratios(self):
-		sargam = ['sa', 're', 'ga', 'ma', 'pa', 'dha', 'ni']
-		ratios = []
-		ct = 0
-		for sIdx, s in enumerate(sargam):
-			if isinstance(self.rule_set.get(s), bool):
-				if self.rule_set.get(s):
-					ratios.append(self.ratios[ct])
-					ct += 1
-				else:
-					ratios.append(self.tuning[s])
-			else:
-				ratios.append([])
-				if self.rule_set[s]['lowered']:
-					ratios[sIdx].append(self.ratios[ct])
-					ct += 1
-				else:
-					ratios[sIdx].append(self.tuning[s]['lowered'])
-				if self.rule_set[s]['raised']:
-					ratios[sIdx].append(self.ratios[ct])
-					ct += 1
-				else:
-					ratios[sIdx].append(self.tuning[s]['raised'])
-		return ratios
+    def get_pitch_numbers(self, low: int, high: int) -> List[int]:
+        pns: List[int] = []
+        for i in range(low, high + 1):
+            chroma = i % 12
+            while chroma < 0:
+                chroma += 12
+            scale_degree, raised = Pitch.chroma_to_scale_degree(chroma)
+            swara = ['sa', 're', 'ga', 'ma', 'pa', 'dha', 'ni'][scale_degree]
+            val = self.rule_set[swara]
+            if isinstance(val, bool):
+                if val:
+                    pns.append(i)
+            else:
+                if val['raised' if raised else 'lowered']:
+                    pns.append(i)
+        return pns
 
-	@property
-	def chikari_pitches(self):
-		return [
-        Pitch(options={'swara': 's', 'oct': 2, 'fundamental': self.fundamental}),
-        Pitch(options={'swara': 's', 'oct': 1, 'fundamental': self.fundamental})
-    	]
+    def pitch_number_to_scale_number(self, pitch_number: int) -> int:
+        octv = pitch_number // 12
+        chroma = pitch_number % 12
+        while chroma < 0:
+            chroma += 12
+        main_oct = self.get_pitch_numbers(0, 11)
+        if chroma not in main_oct:
+            raise ValueError('pitchNumberToScaleNumber: pitchNumber not in raga')
+        idx = main_oct.index(chroma)
+        return idx + octv * len(main_oct)
 
-	def get_frequencies(self, low=100, high=800):
-		base_freqs = [r * self.fundamental for r in self.ratios]
-		freqs = []
+    def scale_number_to_pitch_number(self, scale_number: int) -> int:
+        main_oct = self.get_pitch_numbers(0, 11)
+        octv = scale_number // len(main_oct)
+        while scale_number < 0:
+            scale_number += len(main_oct)
+        chroma = main_oct[scale_number % len(main_oct)]
+        return chroma + octv * 12
 
-		for f in base_freqs:
-			low_exp = math.ceil(math.log2(low / f))
-			high_exp = math.floor(math.log2(high / f))
-			exps = list(range(low_exp, high_exp + 1))
-			additional_freqs = [f * (2.0 ** exp) for exp in exps]
-			freqs.extend(additional_freqs)
+    def scale_number_to_sargam_letter(self, scale_number: int) -> Optional[str]:
+        pn = self.scale_number_to_pitch_number(scale_number)
+        return self.pitch_number_to_sargam_letter(pn)
 
-		freqs.sort()
-		return freqs
+    # ------------------------------------------------------------------
+    def set_ratios(self, rule_set: RuleSetType) -> List[float]:
+        ratios: List[float] = []
+        for s in rule_set.keys():
+            val = rule_set[s]
+            base = et_tuning[s]
+            if isinstance(val, bool):
+                if val:
+                    ratios.append(base)  # type: ignore
+            else:
+                if val.get('lowered'):
+                    ratios.append(base['lowered'])  # type: ignore
+                if val.get('raised'):
+                    ratios.append(base['raised'])  # type: ignore
+        return ratios
 
-	@property
-	def sargam_names(self):
-		names = []
-		sargam = self.rule_set.keys()
+    # ------------------------------------------------------------------
+    def get_pitches(self, low: float = 100, high: float = 800) -> List[Pitch]:
+        pitches: List[Pitch] = []
+        for s, val in self.rule_set.items():
+            if isinstance(val, bool):
+                if val:
+                    freq = float(self.tuning[s]) * self.fundamental  # type: ignore
+                    low_exp = math.ceil(math.log2(low / freq))
+                    high_exp = math.floor(math.log2(high / freq))
+                    for i in range(low_exp, high_exp + 1):
+                        pitches.append(Pitch({'swara': s, 'oct': i, 'fundamental': self.fundamental, 'ratios': self.stratified_ratios}))
+            else:
+                if val.get('lowered'):
+                    freq = self.tuning[s]['lowered'] * self.fundamental  # type: ignore
+                    low_exp = math.ceil(math.log2(low / freq))
+                    high_exp = math.floor(math.log2(high / freq))
+                    for i in range(low_exp, high_exp + 1):
+                        pitches.append(Pitch({'swara': s, 'oct': i, 'raised': False, 'fundamental': self.fundamental, 'ratios': self.stratified_ratios}))
+                if val.get('raised'):
+                    freq = self.tuning[s]['raised'] * self.fundamental  # type: ignore
+                    low_exp = math.ceil(math.log2(low / freq))
+                    high_exp = math.floor(math.log2(high / freq))
+                    for i in range(low_exp, high_exp + 1):
+                        pitches.append(Pitch({'swara': s, 'oct': i, 'raised': True, 'fundamental': self.fundamental, 'ratios': self.stratified_ratios}))
+        pitches.sort(key=lambda p: p.frequency)
+        return [p for p in pitches if low <= p.frequency <= high]
 
-		for s in sargam:
-			if isinstance(self.rule_set[s], dict):  # Check if value is a dictionary
-				obj = self.rule_set[s]
-				if obj.get('raised', False):
-					names.append(s.capitalize())
-				if obj.get('lowered', False):
-					names.append(s.lower())
-			else:
-				if self.rule_set[s]:
-					names.append(s.capitalize())
-		return names
+    @property
+    def stratified_ratios(self) -> List[Union[float, List[float]]]:
+        ratios: List[Union[float, List[float]]] = []
+        ct = 0
+        for s in ['sa', 're', 'ga', 'ma', 'pa', 'dha', 'ni']:
+            val = self.rule_set[s]
+            base = self.tuning[s]
+            if isinstance(val, bool):
+                if val:
+                    ratios.append(self.ratios[ct])
+                    ct += 1
+                else:
+                    ratios.append(base)  # type: ignore
+            else:
+                pair: List[float] = []
+                if val.get('lowered'):
+                    pair.append(self.ratios[ct]); ct += 1
+                else:
+                    pair.append(base['lowered'])  # type: ignore
+                if val.get('raised'):
+                    pair.append(self.ratios[ct]); ct += 1
+                else:
+                    pair.append(base['raised'])  # type: ignore
+                ratios.append(pair)
+        return ratios
 
-	def to_json(self):
-		return {
-        'name': self.name,
-        'fundamental': self.fundamental,
-        'ratios': self.ratios
-    	}
-r = Raga()
+    @property
+    def chikari_pitches(self) -> List[Pitch]:
+        return [
+            Pitch({'swara': 's', 'oct': 2, 'fundamental': self.fundamental}),
+            Pitch({'swara': 's', 'oct': 1, 'fundamental': self.fundamental}),
+        ]
+
+    def get_frequencies(self, low: float = 100, high: float = 800) -> List[float]:
+        freqs: List[float] = []
+        for ratio in self.ratios:
+            base = ratio * self.fundamental
+            low_exp = math.ceil(math.log2(low / base))
+            high_exp = math.floor(math.log2(high / base))
+            for i in range(low_exp, high_exp + 1):
+                freqs.append(base * (2 ** i))
+        freqs.sort()
+        return freqs
+
+    @property
+    def sargam_names(self) -> List[str]:
+        names: List[str] = []
+        for s, val in self.rule_set.items():
+            if isinstance(val, dict):
+                if val.get('lowered'):
+                    names.append(s.lower())
+                if val.get('raised'):
+                    names.append(s.capitalize())
+            else:
+                if val:
+                    names.append(s.capitalize())
+        return names
+
+    @property
+    def swara_objects(self) -> List[Dict[str, Union[int, bool]]]:
+        objs: List[Dict[str, Union[int, bool]]] = []
+        idx = 0
+        for s, val in self.rule_set.items():
+            if isinstance(val, dict):
+                if val.get('lowered'):
+                    objs.append({'swara': idx, 'raised': False})
+                if val.get('raised'):
+                    objs.append({'swara': idx, 'raised': True})
+                idx += 1
+            else:
+                if val:
+                    objs.append({'swara': idx, 'raised': True})
+                idx += 1
+        return objs
+
+    # ------------------------------------------------------------------
+    def pitch_from_log_freq(self, log_freq: float) -> Pitch:
+        epsilon = 1e-6
+        log_options = [math.log2(f) for f in self.get_frequencies(low=75, high=2400)]
+        quantized = min(log_options, key=lambda x: abs(x - log_freq))
+        log_offset = log_freq - quantized
+        log_diff = quantized - math.log2(self.fundamental)
+        rounded = round(log_diff)
+        if abs(log_diff - rounded) < epsilon:
+            log_diff = rounded
+        oct_offset = math.floor(log_diff)
+        log_diff -= oct_offset
+        # find closest ratio index
+        r_idx = 0
+        for i, r in enumerate(self.ratios):
+            if abs(r - 2 ** log_diff) < 1e-6:
+                r_idx = i
+                break
+        swara_letter = self.sargam_letters[r_idx]
+        raised = swara_letter.isupper()
+        return Pitch({
+            'swara': swara_letter,
+            'oct': oct_offset,
+            'fundamental': self.fundamental,
+            'ratios': self.stratified_ratios,
+            'log_offset': log_offset,
+            'raised': raised,
+        })
+
+    def ratio_idx_to_tuning_tuple(self, idx: int) -> Tuple[str, Optional[str]]:
+        mapping: List[Tuple[str, Optional[str]]] = []
+        for key, val in self.rule_set.items():
+            if isinstance(val, dict):
+                if val.get('lowered'):
+                    mapping.append((key, 'lowered'))
+                if val.get('raised'):
+                    mapping.append((key, 'raised'))
+            else:
+                if val:
+                    mapping.append((key, None))
+        return mapping[idx]
+
+    # ------------------------------------------------------------------
+    def to_json(self) -> Dict[str, Union[str, float, List[float], TuningType]]:
+        return {
+            'name': self.name,
+            'fundamental': self.fundamental,
+            'ratios': self.ratios,
+            'tuning': self.tuning,
+        }
+
+    @staticmethod
+    def from_json(obj: Dict) -> 'Raga':
+        return Raga(obj)

--- a/python/api/tests/raga_test.py
+++ b/python/api/tests/raga_test.py
@@ -1,183 +1,545 @@
 import os
 import sys
+import math
+import pytest
+
 sys.path.insert(0, os.path.abspath('.'))
-from python.api.classes.raga import Raga
+
+from python.api.classes.raga import Raga, yaman_rule_set, et_tuning
 from python.api.classes.pitch import Pitch
-import pytest, math
 
-yaman_rule_set = {
-	'sa': True,
-	're': {
-		'lowered': False,
-		'raised': True
-	},
-	'ga': {
-		'lowered': False,
-		'raised': True
-	},
-	'ma': {
-		'lowered': False,
-		'raised': True
-	},
-	'pa': True,
-	'dha': {
-		'lowered': False,
-		'raised': True
-	},
-	'ni': {
-		'lowered': False,
-		'raised': True
-	}
-}
-
-base_tuning = {
-	'sa': 2 ** (0 / 12),
-	're': {
-		'lowered': 2 ** (1 / 12),
-		'raised': 2 ** (2 / 12)
-	},
-	'ga': {
-		'lowered': 2 ** (3 / 12),
-		'raised': 2 ** (4 / 12)
-	},
-	'ma': {
-		'lowered': 2 ** (5 / 12),
-		'raised': 2 ** (6 / 12)
-	},
-	'pa': 2 ** (7 / 12),
-	'dha': {
-		'lowered': 2 ** (8 / 12),
-		'raised': 2 ** (9 / 12)
-	},
-	'ni': {
-		'lowered': 2 ** (10 / 12),
-		'raised': 2 ** (11 / 12)
-	}
-}
+base_tuning = et_tuning
 
 base_ratios = [
-	base_tuning['sa'],
-	base_tuning['re']['raised'],
-	base_tuning['ga']['raised'],
-	base_tuning['ma']['raised'],
-	base_tuning['pa'],
-	base_tuning['dha']['raised'],
-	base_tuning['ni']['raised']
+    base_tuning['sa'],
+    base_tuning['re']['raised'],
+    base_tuning['ga']['raised'],
+    base_tuning['ma']['raised'],
+    base_tuning['pa'],
+    base_tuning['dha']['raised'],
+    base_tuning['ni']['raised'],
 ]
 
+custom_rule_set = {
+    'sa': True,
+    're': {'lowered': True, 'raised': False},
+    'ga': {'lowered': False, 'raised': True},
+    'ma': {'lowered': True, 'raised': True},
+    'pa': True,
+    'dha': {'lowered': True, 'raised': False},
+    'ni': {'lowered': False, 'raised': True},
+}
+
+ratio_mapping = [
+    ('sa', True),
+    ('re', False),
+    ('ga', True),
+    ('ma', False),
+    ('ma', True),
+    ('pa', True),
+    ('dha', False),
+    ('ni', True),
+]
+
+def compute_expected_pitches(r: Raga, low=100, high=800):
+    pitches: list[Pitch] = []
+    for swara, raised in ratio_mapping:
+        ratio = (r.tuning[swara]['raised' if raised else 'lowered']
+                 if isinstance(r.tuning[swara], dict)
+                 else r.tuning[swara])
+        freq = ratio * r.fundamental
+        low_exp = math.ceil(math.log2(low / freq))
+        high_exp = math.floor(math.log2(high / freq))
+        for i in range(low_exp, high_exp + 1):
+            pitches.append(Pitch({'swara': swara, 'oct': i, 'raised': raised,
+                                  'fundamental': r.fundamental, 'ratios': r.stratified_ratios}))
+    pitches.sort(key=lambda p: p.frequency)
+    return [p for p in pitches if low <= p.frequency <= high]
+
+
 def test_default_raga():
-	r = Raga()
-	assert isinstance(r, Raga)
-	assert r.name == 'Yaman'
-	assert r.fundamental == 261.63
-	assert r.rule_set == yaman_rule_set
-	assert r.tuning == base_tuning
-	assert r.ratios == base_ratios
-	assert r.sargam_letters == ['S', 'R', 'G', 'M', 'P', 'D', 'N']
-	assert r.rule_set_num_pitches == 7
-	pitch_nums = list(range(12))
-	sargam_letters = [
-		'S',
-		None,
-		'R',
-		None,
-		'G',
-		None,
-		'M',
-		'P',
-		None,
-		'D',
-		None,
-		'N'
-		]
-	for pn in pitch_nums:
-		assert r.pitch_number_to_sargam_letters(pn) == sargam_letters[pn]
-	single_oct_pns = [0, 2, 4, 6, 7, 9, 11, 12]
-	assert r.get_pitch_numbers(0, 12) == single_oct_pns
-	pns = [
-		-12, -10, -8, -6, -5, -3, -1, 
-		0, 2, 4, 6, 7, 9, 11, 
-		12, 14, 16, 18, 19, 21, 23, 24
-	]
-	assert r.get_pitch_numbers(-12, 24) == pns
-	sns = [
-		-7, -6, -5, -4, -3, -2, -1,
-		0, 1, 2, 3, 4, 5, 6,
-		7, 8, 9, 10, 11, 12, 13, 14
-	]
-	throw_pns = [
-		-11, -9, -7, -4, -2, 
-		1, 3, 5, 8, 10,
-		13, 15, 17, 20, 22 
-	]
+    r = Raga()
+    assert isinstance(r, Raga)
+    assert r.name == 'Yaman'
+    assert r.fundamental == 261.63
+    assert r.rule_set == yaman_rule_set
+    assert r.tuning == base_tuning
+    assert r.ratios == base_ratios
+    assert r.sargam_letters == ['S', 'R', 'G', 'M', 'P', 'D', 'N']
+    assert r.rule_set_num_pitches == 7
 
-	for idx, pn in enumerate(pns):
-		assert r.pitch_number_to_scale_number(pn) == sns[idx]
+    pitch_nums = list(range(12))
+    sargam_letters = ['S', None, 'R', None, 'G', None, 'M', 'P', None, 'D', None, 'N']
+    for pn in pitch_nums:
+        assert r.pitch_number_to_sargam_letter(pn) == sargam_letters[pn]
 
-	for idx, pn in enumerate(throw_pns):
-		with pytest.raises(ValueError):
-			r.pitch_number_to_scale_number(pn)
-	for idx, sn in enumerate(sns):
-		assert r.scale_number_to_pitch_number(sn) == pns[idx]
+    single_oct_pns = [0, 2, 4, 6, 7, 9, 11, 12]
+    assert r.get_pitch_numbers(0, 12) == single_oct_pns
 
-	s_letters = ['S', 'R', 'G', 'M', 'P', 'D', 'N']
-	s_letters = s_letters + s_letters + s_letters
-	s_letters = s_letters + ['S']
-	for idx, sn in enumerate(sns):
-		assert r.scale_number_to_sargam_letter(sn) == s_letters[idx]
-	p_swaras = [
-		5, 6, 
-		0, 1, 2, 3, 4, 5, 6,
-		0, 1, 2, 3, 4, 5, 6,
-		0, 1, 2, 3, 4
-	]
-	p_octs = [
-		-2, -2,
-		-1, -1, -1, -1, -1, -1, -1,
-		0, 0, 0, 0, 0, 0, 0,
-		1, 1, 1, 1, 1
-	]
-	pitches = [Pitch({ 'swara': s, 'oct': p_octs[idx] }) for idx, s in enumerate(p_swaras)]
-	rp = r.get_pitches()
-	print(len(rp), len(pitches))
-	assert r.get_pitches() == pitches
-	s_ratios = [
-		2 ** 0,
-		[2 ** (1 / 12), 2 ** (2 / 12)],
-		[2 ** (3 / 12), 2 ** (4 / 12)],
-		[2 ** (5 / 12), 2 ** (6 / 12)],
-		2 ** (7 / 12),
-		[2 ** (8 / 12), 2 ** (9 / 12)],
-		[2 ** (10 / 12), 2 ** (11 / 12)]
-	]
-	assert r.stratified_ratios == s_ratios
-	assert r.chikari_pitches == [
-		Pitch({ 'swara': 0, 'oct': 2, 'fundamental': 261.63 }),
-		Pitch({ 'swara': 0, 'oct': 1, 'fundamental': 261.63 }),
-	]
-	hard_coded_freqs = [
-		110.00186456141468, 123.47291821345574,
-				130.815, 146.83487284959062,
-		164.81657214199782, 185.00034716183643,
-		196.0010402616231, 220.00372912282936,
-		246.94583642691148,             261.63,
-		293.66974569918125, 329.63314428399565,
-		370.00069432367286,  392.0020805232462,
-		440.0074582456587, 493.89167285382297,
-					523.26,  587.3394913983625,
-		659.2662885679913,  740.0013886473457,
-		784.0041610464924
-	]
-	for idx, freq in enumerate(r.get_frequencies()):
-		assert math.isclose(pitches[idx].frequency, freq, abs_tol=0.000001)
-		assert math.isclose(hard_coded_freqs[idx], freq, abs_tol=0.000001)
-	s_names = ['Sa', 'Re', 'Ga', 'Ma', 'Pa', 'Dha', 'Ni']
-	assert r.sargam_names == s_names
-	json_obj = {
-		'name': 'Yaman',
-		'fundamental': 261.63,
-		'ratios': base_ratios
-	}
-	assert r.to_json() == json_obj
+    pns = [
+        -12, -10, -8, -6, -5, -3, -1,
+        0, 2, 4, 6, 7, 9, 11,
+        12, 14, 16, 18, 19, 21, 23, 24,
+    ]
+    assert r.get_pitch_numbers(-12, 24) == pns
+
+    sns = [
+        -7, -6, -5, -4, -3, -2, -1,
+        0, 1, 2, 3, 4, 5, 6,
+        7, 8, 9, 10, 11, 12, 13, 14,
+    ]
+    throw_pns = [
+        -11, -9, -7, -4, -2,
+        1, 3, 5, 8, 10,
+        13, 15, 17, 20, 22,
+    ]
+
+    for idx, pn in enumerate(pns):
+        assert r.pitch_number_to_scale_number(pn) == sns[idx]
+
+    for pn in throw_pns:
+        with pytest.raises(ValueError):
+            r.pitch_number_to_scale_number(pn)
+
+    for idx, sn in enumerate(sns):
+        assert r.scale_number_to_pitch_number(sn) == pns[idx]
+
+    s_letters = ['S', 'R', 'G', 'M', 'P', 'D', 'N'] * 3 + ['S']
+    for idx, sn in enumerate(sns):
+        assert r.scale_number_to_sargam_letter(sn) == s_letters[idx]
+
+    p_swaras = [
+        5, 6,
+        0, 1, 2, 3, 4, 5, 6,
+        0, 1, 2, 3, 4, 5, 6,
+        0, 1, 2, 3, 4,
+    ]
+    p_octs = [
+        -2, -2,
+        -1, -1, -1, -1, -1, -1, -1,
+        0, 0, 0, 0, 0, 0, 0,
+        1, 1, 1, 1, 1,
+    ]
+    pitches = [Pitch({'swara': s, 'oct': p_octs[idx]}) for idx, s in enumerate(p_swaras)]
+    assert r.get_pitches() == pitches
+
+    s_ratios = [
+        2 ** 0,
+        [2 ** (1 / 12), 2 ** (2 / 12)],
+        [2 ** (3 / 12), 2 ** (4 / 12)],
+        [2 ** (5 / 12), 2 ** (6 / 12)],
+        2 ** (7 / 12),
+        [2 ** (8 / 12), 2 ** (9 / 12)],
+        [2 ** (10 / 12), 2 ** (11 / 12)],
+    ]
+    assert r.stratified_ratios == s_ratios
+    assert r.chikari_pitches == [
+        Pitch({'swara': 0, 'oct': 2, 'fundamental': 261.63}),
+        Pitch({'swara': 0, 'oct': 1, 'fundamental': 261.63}),
+    ]
+
+    hard_coded_freqs = [
+        110.00186456141468, 123.47291821345574,
+        130.815, 146.83487284959062,
+        164.81657214199782, 185.00034716183643,
+        196.0010402616231, 220.00372912282936,
+        246.94583642691148, 261.63,
+        293.66974569918125, 329.63314428399565,
+        370.00069432367286, 392.0020805232462,
+        440.0074582456587, 493.89167285382297,
+        523.26, 587.3394913983625,
+        659.2662885679913, 740.0013886473457,
+        784.0041610464924,
+    ]
+    for idx, freq in enumerate(r.get_frequencies()):
+        assert math.isclose(pitches[idx].frequency, freq, abs_tol=1e-6)
+        assert math.isclose(hard_coded_freqs[idx], freq, abs_tol=1e-6)
+
+    s_names = ['Sa', 'Re', 'Ga', 'Ma', 'Pa', 'Dha', 'Ni']
+    assert r.sargam_names == s_names
+
+    json_obj = {
+        'name': 'Yaman',
+        'fundamental': 261.63,
+        'ratios': base_ratios,
+        'tuning': base_tuning,
+    }
+    assert r.to_json() == json_obj
 
 
+def test_pitch_from_log_freq():
+    r = Raga()
+    offset = 0.03
+    base_log = math.log2(r.fundamental * 2)
+    p = r.pitch_from_log_freq(base_log + offset)
+    assert isinstance(p, Pitch)
+    assert math.isclose(p.frequency, 2 ** (base_log + offset), abs_tol=1e-6)
+
+
+def test_pitch_string_getters():
+    r = Raga()
+    pl = r.get_pitches(low=r.fundamental, high=r.fundamental * 1.999)
+    solfege = [p.solfege_letter for p in pl]
+    pcs = [str(p.chroma) for p in pl]
+    western = [p.western_pitch for p in pl]
+    assert r.solfege_strings == solfege
+    assert r.pc_strings == pcs
+    assert r.western_pitch_strings == western
+
+
+def test_swara_objects():
+    r = Raga()
+    objs = [
+        {'swara': 0, 'raised': True},
+        {'swara': 1, 'raised': True},
+        {'swara': 2, 'raised': True},
+        {'swara': 3, 'raised': True},
+        {'swara': 4, 'raised': True},
+        {'swara': 5, 'raised': True},
+        {'swara': 6, 'raised': True},
+    ]
+    assert r.swara_objects == objs
+
+
+def test_ratio_idx_to_tuning_tuple():
+    r = Raga()
+    mapping = [
+        ('sa', None),
+        ('re', 'raised'),
+        ('ga', 'raised'),
+        ('ma', 'raised'),
+        ('pa', None),
+        ('dha', 'raised'),
+        ('ni', 'raised'),
+    ]
+    for idx, tup in enumerate(mapping):
+        assert r.ratio_idx_to_tuning_tuple(idx) == tup
+
+
+def test_custom_rule_set_pitch_numbers_and_invalid_conversions():
+    r = Raga({'rule_set': custom_rule_set, 'fundamental': 200})
+    expected = [0, 1, 4, 5, 6, 7, 8, 11]
+    assert r.rule_set_num_pitches == len(expected)
+    assert r.get_pitch_numbers(0, 11) == expected
+    for idx, pn in enumerate(expected):
+        assert r.pitch_number_to_scale_number(pn) == idx
+    disallowed = [2, 3, 9, 10]
+    for pn in disallowed:
+        with pytest.raises(ValueError):
+            r.pitch_number_to_scale_number(pn)
+
+
+def test_get_pitches_with_lowered_and_raised_notes():
+    r = Raga({'rule_set': custom_rule_set, 'fundamental': 200})
+    expected = compute_expected_pitches(r)
+    result = r.get_pitches()
+    assert len(result) == len(expected)
+    for idx, p in enumerate(result):
+        assert math.isclose(p.frequency, expected[idx].frequency, abs_tol=1e-6)
+        assert p.swara == expected[idx].swara
+        assert p.oct == expected[idx].oct
+        assert p.raised == expected[idx].raised
+
+
+def test_pitch_from_log_freq_octave_rounding():
+    r = Raga()
+    base = math.log2(r.fundamental)
+    near = base + 1 - 5e-7
+    p1 = r.pitch_from_log_freq(near)
+    assert p1.sargam_letter == 'S'
+    assert p1.oct == 1
+    p2 = r.pitch_from_log_freq(base + 1 + 5e-7)
+    assert p2.sargam_letter == 'S'
+    assert p2.oct == 1
+
+
+def test_pitch_from_log_freq_near_exact_octave_offset():
+    fundamental = 128.5 - 1e-12
+    r = Raga({'fundamental': fundamental})
+    log_freq = math.log2(fundamental * 2)
+    p = r.pitch_from_log_freq(log_freq)
+    assert p.sargam_letter == 'S'
+    assert p.oct == 1
+
+
+def test_ratio_idx_to_tuning_tuple_mixed_rule_set():
+    r = Raga({'rule_set': custom_rule_set})
+    mapping = [
+        ('sa', None),
+        ('re', 'lowered'),
+        ('ga', 'raised'),
+        ('ma', 'lowered'),
+        ('ma', 'raised'),
+        ('pa', None),
+        ('dha', 'lowered'),
+        ('ni', 'raised'),
+    ]
+    for idx, tup in enumerate(mapping):
+        assert r.ratio_idx_to_tuning_tuple(idx) == tup
+
+
+def test_json_round_trip_with_custom_tuning():
+    tuning = {
+        'sa': 1.01,
+        're': {'lowered': 1.02, 'raised': 1.035},
+        'ga': {'lowered': 1.04, 'raised': 1.05},
+        'ma': {'lowered': 1.06, 'raised': 1.07},
+        'pa': 1.08,
+        'dha': {'lowered': 1.09, 'raised': 1.1},
+        'ni': {'lowered': 1.11, 'raised': 1.12},
+    }
+    ratios = [
+        tuning['sa'],
+        tuning['re']['lowered'],
+        tuning['ga']['raised'],
+        tuning['ma']['lowered'],
+        tuning['ma']['raised'],
+        tuning['pa'],
+        tuning['dha']['lowered'],
+        tuning['ni']['raised'],
+    ]
+    r = Raga({'name': 'Custom', 'fundamental': 300, 'rule_set': custom_rule_set, 'tuning': tuning, 'ratios': ratios})
+    json_obj = r.to_json()
+    round_trip = Raga.from_json({**json_obj, 'rule_set': custom_rule_set})
+    assert round_trip.to_json() == json_obj
+
+# Additional raga utilities
+additional_rule_set = {
+    'sa': True,
+    're': {'lowered': True, 'raised': False},
+    'ga': {'lowered': False, 'raised': True},
+    'ma': {'lowered': True, 'raised': True},
+    'pa': True,
+    'dha': {'lowered': False, 'raised': True},
+    'ni': {'lowered': True, 'raised': False},
+}
+
+fundamental = 200
+
+def et(n: int):
+    return 2 ** (n / 12)
+
+expected_ratios = [
+    et(0),
+    et(1),
+    et(4),
+    et(5),
+    et(6),
+    et(7),
+    et(9),
+    et(10),
+]
+
+expected_stratified = [
+    et(0),
+    [et(1), et(2)],
+    [et(3), et(4)],
+    [et(5), et(6)],
+    et(7),
+    [et(8), et(9)],
+    [et(10), et(11)],
+]
+
+def compute_freqs(r: Raga, low=100, high=800):
+    freqs: list[float] = []
+    for ratio in expected_ratios:
+        base = ratio * r.fundamental
+        low_exp = math.ceil(math.log2(low / base))
+        high_exp = math.floor(math.log2(high / base))
+        for i in range(low_exp, high_exp + 1):
+            freqs.append(base * 2 ** i)
+    freqs.sort()
+    return freqs
+
+mapping_additional = [
+    ('sa', None),
+    ('re', 'lowered'),
+    ('ga', 'raised'),
+    ('ma', 'lowered'),
+    ('ma', 'raised'),
+    ('pa', None),
+    ('dha', 'raised'),
+    ('ni', 'lowered'),
+]
+
+def test_set_ratios_and_stratified_ratios_with_custom_rules():
+    r = Raga({'rule_set': additional_rule_set, 'fundamental': fundamental})
+    assert r.set_ratios(additional_rule_set) == expected_ratios
+    assert len(r.ratios) == len(expected_ratios)
+    for idx, ratio in enumerate(expected_ratios):
+        assert math.isclose(r.ratios[idx], ratio, abs_tol=1e-6)
+    assert len(r.stratified_ratios) == len(expected_stratified)
+    for idx, ratio in enumerate(expected_stratified):
+        if isinstance(ratio, list):
+            assert r.stratified_ratios[idx] == ratio
+        else:
+            assert math.isclose(r.stratified_ratios[idx], ratio, abs_tol=1e-6)
+
+
+def test_from_json_frequencies_and_helper_mappings():
+    r = Raga({'rule_set': additional_rule_set, 'fundamental': fundamental})
+    json_obj = r.to_json()
+    copy = Raga.from_json({**json_obj, 'rule_set': additional_rule_set})
+    assert copy.to_json() == json_obj
+
+    freqs = r.get_frequencies()
+    expected_freqs = compute_freqs(r)
+    assert len(freqs) == len(expected_freqs)
+    for idx, f in enumerate(freqs):
+        assert math.isclose(f, expected_freqs[idx], abs_tol=1e-6)
+
+    chosen = freqs[4]
+    p = r.pitch_from_log_freq(math.log2(chosen))
+    assert isinstance(p, Pitch)
+    assert math.isclose(p.frequency, chosen, abs_tol=1e-6)
+
+    for idx, tup in enumerate(mapping_additional):
+        assert r.ratio_idx_to_tuning_tuple(idx) == tup
+
+
+def test_pitch_number_to_scale_number_edge_cases():
+    r = Raga({'rule_set': additional_rule_set, 'fundamental': fundamental})
+    allowed = r.get_pitch_numbers(0, 11)
+    for idx, pn in enumerate(allowed):
+        assert r.pitch_number_to_scale_number(pn) == idx
+    disallowed = [2, 3, 8, 11]
+    for pn in disallowed:
+        with pytest.raises(ValueError):
+            r.pitch_number_to_scale_number(pn)
+
+
+def test_raga_conversion_helpers():
+    r = Raga({'rule_set': additional_rule_set, 'fundamental': fundamental})
+    pitch_numbers = [0, 1, 4, 5, 6, 7, 9, 10]
+    letters = ['S', 'r', 'G', 'm', 'M', 'P', 'D', 'n']
+    for idx, pn in enumerate(pitch_numbers):
+        assert r.pitch_number_to_sargam_letter(pn) == letters[idx]
+        assert r.pitch_number_to_scale_number(pn) == idx
+        assert r.scale_number_to_pitch_number(idx) == pn
+        assert r.scale_number_to_sargam_letter(idx) == letters[idx]
+    length = len(pitch_numbers)
+    assert r.scale_number_to_pitch_number(length) == pitch_numbers[0] + 12
+    assert r.scale_number_to_pitch_number(length + 1) == pitch_numbers[1] + 12
+    invalid_pns = [2, 3, 8, 11]
+    for pn in invalid_pns:
+        assert r.pitch_number_to_sargam_letter(pn) is None
+        with pytest.raises(ValueError):
+            r.pitch_number_to_scale_number(pn)
+
+# Custom rule set utilities
+custom_local_rule_set = {
+    'sa': True,
+    're': {'lowered': True, 'raised': False},
+    'ga': {'lowered': False, 'raised': True},
+    'ma': {'lowered': True, 'raised': True},
+    'pa': True,
+    'dha': {'lowered': True, 'raised': False},
+    'ni': {'lowered': False, 'raised': True},
+}
+
+expected_ratios_local = [
+    2 ** (0 / 12),
+    2 ** (1 / 12),
+    2 ** (4 / 12),
+    2 ** (5 / 12),
+    2 ** (6 / 12),
+    2 ** (7 / 12),
+    2 ** (8 / 12),
+    2 ** (11 / 12),
+]
+
+ratio_mapping_local = [
+    ('sa', True, expected_ratios_local[0]),
+    ('re', False, expected_ratios_local[1]),
+    ('ga', True, expected_ratios_local[2]),
+    ('ma', False, expected_ratios_local[3]),
+    ('ma', True, expected_ratios_local[4]),
+    ('pa', True, expected_ratios_local[5]),
+    ('dha', False, expected_ratios_local[6]),
+    ('ni', True, expected_ratios_local[7]),
+]
+
+def compute_expected_pitches_local(r: Raga, low=100, high=800):
+    pitches: list[Pitch] = []
+    for swara, raised, ratio in ratio_mapping_local:
+        freq = ratio * r.fundamental
+        low_exp = math.ceil(math.log2(low / freq))
+        high_exp = math.floor(math.log2(high / freq))
+        for i in range(low_exp, high_exp + 1):
+            pitches.append(Pitch({'swara': swara, 'oct': i, 'raised': raised,
+                                  'fundamental': r.fundamental, 'ratios': r.stratified_ratios}))
+    pitches.sort(key=lambda p: p.frequency)
+    return [p for p in pitches if low <= p.frequency <= high]
+
+def compute_expected_freqs_local(r: Raga, low=100, high=800):
+    freqs: list[float] = []
+    for ratio in expected_ratios_local:
+        base = ratio * r.fundamental
+        low_exp = math.ceil(math.log2(low / base))
+        high_exp = math.floor(math.log2(high / base))
+        for i in range(low_exp, high_exp + 1):
+            freqs.append(base * 2 ** i)
+    freqs.sort()
+    return freqs
+
+pitch_numbers_single_oct = [0, 1, 4, 5, 6, 7, 8, 11]
+
+def test_custom_rule_set_basic_functions():
+    r = Raga({'rule_set': custom_local_rule_set, 'fundamental': fundamental})
+    assert r.rule_set_num_pitches == 8
+    for idx, pn in enumerate(pitch_numbers_single_oct):
+        assert r.get_pitch_numbers(0, 11)[idx] == pn
+    for idx, ratio in enumerate(expected_ratios_local):
+        assert math.isclose(r.ratios[idx], ratio, abs_tol=1e-6)
+    from_set = r.set_ratios(custom_local_rule_set)
+    for idx, ratio in enumerate(from_set):
+        assert math.isclose(r.ratios[idx], ratio, abs_tol=1e-6)
+
+
+def test_get_pitches_frequencies_and_flags():
+    r = Raga({'rule_set': custom_local_rule_set, 'fundamental': fundamental})
+    expected = compute_expected_pitches_local(r)
+    result = r.get_pitches()
+    assert len(result) == len(expected)
+    for idx, p in enumerate(result):
+        assert math.isclose(p.frequency, expected[idx].frequency, abs_tol=1e-6)
+        assert p.swara == expected[idx].swara
+        assert p.oct == expected[idx].oct
+        assert p.raised == expected[idx].raised
+
+
+def test_frequency_helpers_with_custom_rule_set():
+    r = Raga({'rule_set': custom_local_rule_set, 'fundamental': fundamental})
+    expected_freqs = compute_expected_freqs_local(r)
+    freqs = r.get_frequencies()
+    assert len(freqs) == len(expected_freqs)
+    for idx, f in enumerate(freqs):
+        assert math.isclose(f, expected_freqs[idx], abs_tol=1e-6)
+
+    pick_freq = freqs[3]
+    p = r.pitch_from_log_freq(math.log2(pick_freq))
+    assert math.isclose(p.frequency, pick_freq, abs_tol=1e-6)
+
+    mapping = [
+        ('sa', None),
+        ('re', 'lowered'),
+        ('ga', 'raised'),
+        ('ma', 'lowered'),
+        ('ma', 'raised'),
+        ('pa', None),
+        ('dha', 'lowered'),
+        ('ni', 'raised'),
+    ]
+    for idx, tup in enumerate(mapping):
+        assert r.ratio_idx_to_tuning_tuple(idx) == tup
+
+
+def test_model_raga_string_getters():
+    r = Raga()
+    pl = r.get_pitches(low=r.fundamental, high=r.fundamental * 1.999)
+    solfege = [p.solfege_letter for p in pl]
+    pcs = [str(p.chroma) for p in pl]
+    western = [p.western_pitch for p in pl]
+    assert r.solfege_strings == solfege
+    assert r.pc_strings == pcs
+    assert r.western_pitch_strings == western


### PR DESCRIPTION
## Summary
- mirror all raga tests from the TS suite into Python
- enhance `Raga` implementation to cover all required functionality
- fallback `decamelize` helpers when `humps` is unavailable
- update `Pitch` class to use the helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ed807e480832ea7c1c1579df46559