### PR TITLE
Port Automation to Python

### DIFF
--- a/python/api/classes/automation.py
+++ b/python/api/classes/automation.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+from typing import List, TypedDict, Optional, Dict
+
+try:
+    import humps
+    decamelize = humps.decamelize  # type: ignore
+except Exception:
+    import re
+    def decamelize(obj):
+        if isinstance(obj, dict):
+            out = {}
+            for k, v in obj.items():
+                s = re.sub(r'(?<!^)(?=[A-Z])', '_', k).lower()
+                out[s] = decamelize(v) if isinstance(v, dict) else v
+            return out
+        return obj
+
+
+def get_starts(dur_array: List[float]) -> List[float]:
+    starts = [0.0]
+    total = 0.0
+    for dur in dur_array[:-1]:
+        total += dur
+        starts.append(total)
+    return starts
+
+
+def get_ends(dur_array: List[float]) -> List[float]:
+    ends = []
+    total = 0.0
+    for dur in dur_array:
+        total += dur
+        ends.append(total)
+    return ends
+
+
+def close_to(a: float, b: float) -> bool:
+    return abs(a - b) < 1e-6
+
+
+class AutomationValueType(TypedDict):
+    norm_time: float
+    value: float
+
+
+class AutomationOptionsType(TypedDict, total=False):
+    values: List[AutomationValueType]
+
+
+class Automation:
+    def __init__(self, options: Optional[AutomationOptionsType] = None) -> None:
+        opts = decamelize(options or {})
+        self.values: List[AutomationValueType] = [
+            {'norm_time': v['norm_time'], 'value': v['value']} for v in opts.get('values', [])
+        ]
+        if len(self.values) == 0:
+            self.values.append({'norm_time': 0.0, 'value': 1.0})
+            self.values.append({'norm_time': 1.0, 'value': 1.0})
+
+    # ------------------------------------------------------------------
+    def add_value(self, norm_time: float, value: float) -> None:
+        if norm_time < 0 or norm_time > 1:
+            raise SyntaxError(f"invalid normTime, must be between 0 and 1: {norm_time}")
+        if value < 0 or value > 1:
+            raise SyntaxError(f"invalid value, must be between 0 and 1: {value}")
+
+        idx = next((i for i, v in enumerate(self.values) if v['norm_time'] == norm_time), -1)
+        if idx != -1:
+            self.values[idx]['value'] = value
+        else:
+            self.values.append({'norm_time': norm_time, 'value': value})
+            self.values.sort(key=lambda x: x['norm_time'])
+
+    # ------------------------------------------------------------------
+    def remove_value(self, idx: int) -> None:
+        if idx < 0 or idx > len(self.values) - 1:
+            raise SyntaxError(f"invalid idx, must be between 0 and {len(self.values) - 1}: {idx}")
+        if idx == 0 or idx == len(self.values) - 1:
+            raise SyntaxError("cannot remove first or last value")
+        self.values.pop(idx)
+
+    # ------------------------------------------------------------------
+    def value_at_x(self, x: float) -> float:
+        if x < 0 or x > 1:
+            raise SyntaxError(f"invalid x, must be between 0 and 1: {x}")
+        idx = -1
+        for i in range(len(self.values) - 1, -1, -1):
+            if self.values[i]['norm_time'] <= x:
+                idx = i
+                break
+        if idx == -1:
+            raise SyntaxError(f"invalid x, must be between 0 and 1: {x}")
+        elif idx == len(self.values) - 1:
+            return self.values[idx]['value']
+        else:
+            start = self.values[idx]
+            end = self.values[idx + 1]
+            slope = (end['value'] - start['value']) / (end['norm_time'] - start['norm_time'])
+            return start['value'] + slope * (x - start['norm_time'])
+
+    # ------------------------------------------------------------------
+    def generate_value_curve(self, value_dur: float, duration: float, max_val: float = 1.0) -> List[float]:
+        value_ct = round(duration / value_dur)
+        self.values.sort(key=lambda x: x['norm_time'])
+        norm_times = [i / value_ct for i in range(value_ct + 1)]
+        return [max_val * self.value_at_x(nt) for nt in norm_times]
+
+    # ------------------------------------------------------------------
+    def partition(self, dur_array: List[float]) -> List['Automation']:
+        starts = get_starts(dur_array)
+        ends = get_ends(dur_array)
+        new_automations: List[Automation] = []
+        for start, end in zip(starts, ends):
+            start_val = self.value_at_x(start)
+            end_val = self.value_at_x(end)
+            new_automations.append(
+                Automation({'values': [
+                    {'norm_time': 0.0, 'value': start_val},
+                    {'norm_time': 1.0, 'value': end_val}
+                ]})
+            )
+        for v in self.values:
+            if v['norm_time'] not in starts and v['norm_time'] not in ends:
+                for i in range(len(starts)):
+                    if starts[i] < v['norm_time'] < ends[i]:
+                        dur = ends[i] - starts[i]
+                        rel_norm_time = (v['norm_time'] - starts[i]) / dur if dur != 0 else 0
+                        new_automations[i].add_value(rel_norm_time, v['value'])
+        return new_automations
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def compress(automations: List['Automation'], dur_array: List[float]) -> 'Automation':
+        all_values: List[AutomationValueType] = []
+        dur_accumulator = 0.0
+        for a, dur in zip(automations, dur_array):
+            rel_values = [
+                {'norm_time': v['norm_time'] * dur + dur_accumulator, 'value': v['value']}
+                for v in a.values
+            ]
+            all_values.extend(rel_values)
+            dur_accumulator += dur
+        unique: List[AutomationValueType] = []
+        seen = set()
+        for v in all_values:
+            if v['norm_time'] not in seen:
+                unique.append(v)
+                seen.add(v['norm_time'])
+        all_values = unique
+        changed = True
+        while changed:
+            changed = False
+            for i in range(len(all_values) - 2):
+                a = all_values[i]
+                b = all_values[i + 1]
+                c = all_values[i + 2]
+                slope1 = (b['value'] - a['value']) / (b['norm_time'] - a['norm_time'])
+                slope2 = (c['value'] - b['value']) / (c['norm_time'] - b['norm_time'])
+                if close_to(slope1, slope2):
+                    all_values.pop(i + 1)
+                    changed = True
+                    break
+        return Automation({'values': all_values})
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def from_json(obj: Dict) -> 'Automation':
+        return Automation(obj)

--- a/python/api/tests/automation_test.py
+++ b/python/api/tests/automation_test.py
@@ -1,0 +1,167 @@
+import os
+import sys
+import json
+import random
+import pytest
+
+sys.path.insert(0, os.path.abspath('.'))
+
+from python.api.classes.automation import Automation
+
+# Tests mirror src/ts/tests/automation.test.ts
+
+def test_automation_basic():
+    a = Automation()
+    assert isinstance(a, Automation)
+    assert a.values[0]['norm_time'] == 0
+    assert a.values[0]['value'] == 1
+    val_curve = a.generate_value_curve(0.1, 1)
+    assert len(val_curve) == 11
+    assert val_curve[0] == pytest.approx(1)
+
+    with pytest.raises(SyntaxError):
+        a.add_value(1.5, 0.5)
+    with pytest.raises(SyntaxError):
+        a.add_value(-0.5, 0.5)
+    with pytest.raises(SyntaxError):
+        a.add_value(0.5, -0.5)
+    with pytest.raises(SyntaxError):
+        a.add_value(0.5, 1.5)
+
+    a.add_value(1, 0)
+    assert len(a.values) == 2
+    val_curve2 = a.generate_value_curve(0.1, 1)
+    for i in range(11):
+        assert val_curve2[i] == pytest.approx(1 - i / 10)
+
+    a.add_value(0.5, 0.2)
+    assert len(a.values) == 3
+    val_curve3 = a.generate_value_curve(0.1, 1)
+    expected_vals = [
+        1, 0.84, 0.68, 0.52, 0.36, 0.2,
+        0.16, 0.12, 0.08, 0.04, 0
+    ]
+    for i in range(11):
+        assert val_curve3[i] == pytest.approx(expected_vals[i])
+
+
+def test_partition_and_compress():
+    orig = Automation()
+    orig.add_value(1, 0)
+    dur_array = [0.4, 0.6]
+    children = orig.partition(dur_array)
+    assert len(children) == 2
+    c1, c2 = children
+    assert len(c1.values) == 2
+    assert len(c2.values) == 2
+    assert c1.values[0]['norm_time'] == 0
+    assert c1.values[0]['value'] == 1
+    assert c1.values[1]['norm_time'] == 1
+    assert c1.values[1]['value'] == pytest.approx(0.6)
+    assert c2.values[0]['norm_time'] == 0
+    assert c2.values[0]['value'] == pytest.approx(0.6)
+    assert c2.values[1]['norm_time'] == 1
+    assert c2.values[1]['value'] == 0
+    assert c1.value_at_x(0.5) == pytest.approx(0.8)
+    assert c2.value_at_x(0.5) == pytest.approx(0.3)
+
+    compressed = Automation.compress(children, dur_array)
+    assert len(compressed.values) == 2
+    assert compressed.values[0]['norm_time'] == 0
+    assert compressed.values[0]['value'] == 1
+    assert compressed.values[1]['norm_time'] == 1
+    assert compressed.values[1]['value'] == 0
+
+    orig2 = Automation()
+    times = [0.13, 0.38, 0.44, 0.6, 0.77777, 0.912345]
+    vals = [random.random() for _ in times]
+    for t, v in zip(times, vals):
+        orig2.add_value(t, v)
+    dur_array2 = [0.25, 0.3, 0.45]
+    children2 = orig2.partition(dur_array2)
+    assert len(children2) == 3
+    compressed2 = Automation.compress(children2, dur_array2)
+    assert len(compressed2.values) == 8
+    returned_times = [v['norm_time'] for v in compressed2.values]
+    suplemented_times = [0] + times + [1]
+    for r, s in zip(returned_times, suplemented_times):
+        assert r == pytest.approx(s)
+
+    a1 = Automation()
+    a2 = Automation()
+    dur_array3 = [0.4, 0.6]
+    new_auto = Automation.compress([a1, a2], dur_array3)
+    assert len(new_auto.values) == 2
+
+
+def test_from_json_round_trip():
+    orig = Automation()
+    orig.add_value(0.3, 0.7)
+    orig.add_value(0.8, 0.4)
+    json_obj = json.loads(json.dumps({'values': orig.values}))
+    clone = Automation.from_json(json_obj)
+    assert isinstance(clone, Automation)
+    assert clone.values == orig.values
+
+
+def test_remove_value_bounds():
+    a = Automation()
+    a.add_value(0.5, 0.5)
+    length = len(a.values)
+    with pytest.raises(SyntaxError):
+        a.remove_value(-1)
+    with pytest.raises(SyntaxError):
+        a.remove_value(length)
+    with pytest.raises(SyntaxError):
+        a.remove_value(0)
+    with pytest.raises(SyntaxError):
+        a.remove_value(length - 1)
+    a.remove_value(1)
+    assert len(a.values) == length - 1
+
+
+def test_value_at_x_bounds():
+    a = Automation()
+    with pytest.raises(SyntaxError):
+        a.value_at_x(-0.1)
+    with pytest.raises(SyntaxError):
+        a.value_at_x(1.1)
+
+
+def test_partition_with_zero_length_segment():
+    orig = Automation()
+    orig.add_value(1, 0)
+    dur_array = [0.4, 0, 0.6]
+    parts = orig.partition(dur_array)
+    assert len(parts) == 3
+
+    env1 = parts[0].generate_value_curve(0.1, 1)
+    env2 = parts[1].generate_value_curve(0.1, 1)
+    env3 = parts[2].generate_value_curve(0.1, 1)
+
+    expected1 = [
+        1, 0.96, 0.92, 0.88, 0.84,
+        0.8, 0.76, 0.72, 0.68,
+        0.64, 0.6
+    ]
+    for i in range(len(env1)):
+        assert env1[i] == pytest.approx(expected1[i])
+
+    for val in env2:
+        assert val == pytest.approx(0.6)
+
+    expected3 = [0.6, 0.54, 0.48, 0.42, 0.36, 0.3, 0.24, 0.18, 0.12, 0.06, 0]
+    for i in range(len(env3)):
+        assert env3[i] == pytest.approx(expected3[i])
+
+
+def test_value_at_x_before_first_value():
+    auto = Automation({
+        'values': [
+            {'norm_time': 0.2, 'value': 0.5},
+            {'norm_time': 1, 'value': 1}
+        ]
+    })
+    with pytest.raises(SyntaxError):
+        auto.value_at_x(0.1)
+


### PR DESCRIPTION
## Summary
- implement `Automation` class in Python ported from TypeScript
- add unit tests mirroring `automation.test.ts`

## Testing
- `pytest -q python/api/tests/automation_test.py`
- `pytest -q python/api/tests`

------
https://chatgpt.com/codex/tasks/task_e_685edc26c19c832e86f38395a22b5002