### PR TITLE
Port chikari to Python

### DIFF
--- a/python/api/classes/chikari.py
+++ b/python/api/classes/chikari.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+from typing import List, Optional, Dict, TypedDict
+import uuid
+
+try:
+    import humps
+    decamelize = humps.decamelize  # type: ignore
+except Exception:  # pragma: no cover - fallback for missing humps
+    import re
+    def decamelize(obj):
+        if isinstance(obj, dict):
+            out = {}
+            for k, v in obj.items():
+                s = re.sub(r'(?<!^)(?=[A-Z])', '_', k).lower()
+                out[s] = decamelize(v) if isinstance(v, dict) else v
+            return out
+        return obj
+
+from .pitch import Pitch
+
+
+class ChikariOptionsType(TypedDict, total=False):
+    pitches: List[Pitch] | List[Dict]
+    fundamental: float
+    unique_id: str
+
+
+class Chikari:
+    def __init__(self, options: Optional[ChikariOptionsType] = None) -> None:
+        opts = decamelize(options or {})
+
+        default_pitches = [
+            Pitch({'swara': 's', 'oct': 2}),
+            Pitch({'swara': 's', 'oct': 1}),
+            Pitch({'swara': 'p', 'oct': 0}),
+            Pitch({'swara': 'g', 'oct': 0}),
+        ]
+        pitches_in = opts.get('pitches', default_pitches)
+        fundamental = opts.get('fundamental', Pitch().fundamental)
+        unique_id = opts.get('unique_id')
+
+        self.unique_id: str = str(unique_id) if unique_id is not None else str(uuid.uuid4())
+        self.fundamental: float = fundamental
+
+        self.pitches: List[Pitch] = []
+        for p in pitches_in:
+            if not isinstance(p, Pitch):
+                p = Pitch(p)  # type: ignore[arg-type]
+            p.fundamental = self.fundamental
+            self.pitches.append(p)
+
+    # ------------------------------------------------------------------
+    def to_json(self) -> Dict:
+        return {
+            'fundamental': self.fundamental,
+            'pitches': [p.to_JSON() for p in self.pitches],
+            'uniqueId': self.unique_id,
+        }
+
+    @staticmethod
+    def from_json(obj: Dict) -> 'Chikari':
+        opts = decamelize(obj)
+        pitches = [Pitch.from_json(p) for p in opts.get('pitches', [])]
+        opts['pitches'] = pitches
+        return Chikari(opts)  # type: ignore[arg-type]

--- a/python/api/tests/chikari_test.py
+++ b/python/api/tests/chikari_test.py
@@ -1,0 +1,16 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath('.'))
+
+from python.api.classes.chikari import Chikari
+from python.api.classes.pitch import Pitch
+
+# Test mirrors src/js/tests/chikari.test.ts
+
+def test_chikari_serialization():
+    pitches = [Pitch({'swara': 's', 'oct': 1}), Pitch({'swara': 'p'})]
+    c = Chikari({'pitches': pitches, 'fundamental': 440})
+    assert isinstance(c.unique_id, str)
+    json_obj = c.to_json()
+    copy = Chikari.from_json(json_obj)
+    assert copy.to_json() == json_obj


### PR DESCRIPTION
## Summary
- add `chikari.py` with python implementation of the TS class
- port TS tests to `chikari_test.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ede951b8c832eacbedeafc20d1262