### PR TITLE
Add NoteViewPhrase class

### DIFF
--- a/python/api/classes/note_view_phrase.py
+++ b/python/api/classes/note_view_phrase.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+from typing import List, Optional, Dict, Any
+
+from .pitch import Pitch
+from .raga import Raga
+
+
+class NoteViewPhrase:
+    def __init__(self, options: Optional[Dict[str, Any]] = None) -> None:
+        opts = options or {}
+        self.pitches: List[Pitch] = opts.get('pitches', [])
+        self.dur_tot: Optional[float] = opts.get('dur_tot')
+        self.raga: Optional[Raga] = opts.get('raga')
+        self.start_time: Optional[float] = opts.get('start_time')

--- a/python/api/classes/phrase.py
+++ b/python/api/classes/phrase.py
@@ -22,6 +22,7 @@ from .chikari import Chikari
 from .group import Group
 from .pitch import Pitch
 from .automation import get_starts
+from .note_view_phrase import NoteViewPhrase
 
 
 PhraseCatType = Dict[str, Dict[str, bool]]
@@ -463,10 +464,3 @@ class Phrase:
         self.assign_traj_nums()
 
 
-class NoteViewPhrase:
-    def __init__(self, options: Optional[Dict[str, Any]] = None) -> None:
-        opts = options or {}
-        self.pitches: List[Pitch] = opts.get('pitches', [])
-        self.dur_tot: Optional[float] = opts.get('dur_tot')
-        self.raga: Optional[Raga] = opts.get('raga')
-        self.start_time: Optional[float] = opts.get('start_time')

--- a/python/api/tests/note_view_phrase_test.py
+++ b/python/api/tests/note_view_phrase_test.py
@@ -1,0 +1,17 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath('.'))
+
+from python.api.classes.note_view_phrase import NoteViewPhrase
+from python.api.classes.pitch import Pitch
+from python.api.classes.raga import Raga
+
+
+def test_note_view_phrase_basic():
+    r = Raga()
+    nv = NoteViewPhrase({'pitches': [Pitch()], 'dur_tot': 1, 'raga': r, 'start_time': 0})
+    assert len(nv.pitches) == 1
+    assert nv.dur_tot == 1
+    assert isinstance(nv.raga, Raga)
+    assert nv.start_time == 0


### PR DESCRIPTION
## Summary
- add `note_view_phrase.py` for NoteViewPhrase class
- expose NoteViewPhrase from `phrase.py`
- create Python tests for NoteViewPhrase

## Testing
- `pytest -q python/api/tests`

------
https://chatgpt.com/codex/tasks/task_e_685ef025c9e4832e8d05569ae4ec65b5