### PR TITLE
Add Swara API client and packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,27 @@ For more information, and for citing this project, please see our [preprint arti
 This project has been supported by grants from the National Endowment for the Humanities Office of Digital Humanities, the Arts Research Institute at UC Santa Cruz, and the Hasan & Ali Akbar Khan Endowment for Classical Indian Music.
 
 This project is tested with BrowserStack
+
+## Python API
+
+The `python/api` package provides data classes and a small client for
+interacting with the API served at [swara.studio](https://swara.studio).
+Install it with `pip` and the provided `pyproject.toml`:
+
+```bash
+pip install -e python/api
+```
+
+Basic usage:
+
+```python
+from python.api import SwaraClient, Piece
+client = SwaraClient()
+piece_json = client.get_piece("abc123")
+```
+
+Unit tests can be run with `pytest`:
+
+```bash
+pytest python/api/tests
+```

--- a/python/api/__init__.py
+++ b/python/api/__init__.py
@@ -1,0 +1,37 @@
+"""Python API package exposing IDTAP data classes and client."""
+
+from .client import SwaraClient
+
+from .classes.articulation import Articulation
+from .classes.automation import Automation  # type: ignore
+from .classes.assemblage import Assemblage
+from .classes.chikari import Chikari
+from .classes.group import Group
+from .classes.meter import Meter
+from .classes.note_view_phrase import NoteViewPhrase
+from .classes.piece import Piece
+from .classes.phrase import Phrase
+from .classes.pitch import Pitch
+from .classes.raga import Raga
+from .classes.section import Section
+from .classes.trajectory import Trajectory
+
+from .enums import Instrument
+
+__all__ = [
+    "SwaraClient",
+    "Articulation",
+    "Automation",
+    "Assemblage",
+    "Chikari",
+    "Group",
+    "Meter",
+    "NoteViewPhrase",
+    "Piece",
+    "Phrase",
+    "Pitch",
+    "Raga",
+    "Section",
+    "Trajectory",
+    "Instrument",
+]

--- a/python/api/client.py
+++ b/python/api/client.py
@@ -1,0 +1,81 @@
+"""HTTP client for the Swara Studio API."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+import requests
+
+
+class SwaraClient:
+    """Minimal client wrapping the public API served at https://swara.studio."""
+
+    def __init__(self, base_url: str = "https://swara.studio/") -> None:
+        self.base_url = base_url.rstrip("/") + "/"
+
+    def _post_json(self, endpoint: str, payload: Dict[str, Any]) -> Any:
+        url = self.base_url + endpoint
+        response = requests.post(url, json=payload)
+        response.raise_for_status()
+        if response.content:
+            return response.json()
+        return None
+
+    def _get(self, endpoint: str, params: Optional[Dict[str, Any]] = None) -> Any:
+        url = self.base_url + endpoint
+        response = requests.get(url, params=params)
+        response.raise_for_status()
+        ctype = response.headers.get("Content-Type", "")
+        if ctype.startswith("application/json"):
+            return response.json()
+        return response.content
+
+    # ---- API methods ----
+    def get_piece(self, piece_id: str) -> Any:
+        """Return transcription JSON for the given id."""
+        return self._post_json("getOneTranscription", {"_id": piece_id})
+
+    def piece_exists(self, piece_id: str) -> Any:
+        return self._get("pieceExists", params={"_id": piece_id})
+
+    def excel_data(self, piece_id: str) -> bytes:
+        return self._get("excelData", params={"_id": piece_id})
+
+    def json_data(self, piece_id: str) -> bytes:
+        return self._get("jsonData", params={"_id": piece_id})
+
+    def get_audio_db_entry(self, _id: str) -> Any:
+        return self._post_json("getAudioDBEntry", {"_id": _id})
+
+    def save_piece(self, piece: Dict[str, Any]) -> Any:
+        return self._post_json("updateTranscription", piece)
+
+    def get_all_pieces(
+        self,
+        user_id: str,
+        sort_key: str = "title",
+        sort_dir: str | int = 1,
+        new_permissions: Optional[bool] = None,
+    ) -> Any:
+        params = {
+            "userID": user_id,
+            "sortKey": sort_key,
+            "sortDir": sort_dir,
+            "newPermissions": new_permissions,
+        }
+        # remove None values
+        params = {k: str(v) for k, v in params.items() if v is not None}
+        return self._get("getAllTranscriptions", params=params)
+
+    def update_visibility(
+        self,
+        artifact_type: str,
+        _id: str,
+        explicit_permissions: Dict[str, Any],
+    ) -> Any:
+        payload = {
+            "artifactType": artifact_type,
+            "_id": _id,
+            "explicitPermissions": explicit_permissions,
+        }
+        return self._post_json("updateVisibility", payload)

--- a/python/api/pyproject.toml
+++ b/python/api/pyproject.toml
@@ -1,0 +1,8 @@
+[project]
+name = "idtap_api"
+version = "0.1.0"
+description = "Python API client and data classes for the IDTAP project"
+dependencies = ["requests", "pymongo"]
+
+[project.optional-dependencies]
+test = ["pytest", "responses"]

--- a/python/api/tests/client_test.py
+++ b/python/api/tests/client_test.py
@@ -1,0 +1,34 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath('.'))
+
+import responses
+import pytest
+
+from python.api.client import SwaraClient
+
+BASE = 'https://swara.studio/'
+
+@responses.activate
+def test_get_piece():
+    client = SwaraClient()
+    endpoint = BASE + 'getOneTranscription'
+    responses.post(endpoint, json={'_id': '1'}, status=200)
+    result = client.get_piece('1')
+    assert result == {'_id': '1'}
+
+@responses.activate
+def test_piece_exists():
+    client = SwaraClient()
+    endpoint = BASE + 'pieceExists'
+    responses.get(endpoint, json={'exists': True}, status=200)
+    result = client.piece_exists('1')
+    assert result == {'exists': True}
+
+@responses.activate
+def test_save_piece():
+    client = SwaraClient()
+    endpoint = BASE + 'updateTranscription'
+    responses.post(endpoint, json={'ok': 1}, status=200)
+    result = client.save_piece({'_id': '1'})
+    assert result == {'ok': 1}


### PR DESCRIPTION
## Summary
- add pyproject for python/api package with basic dependencies
- implement `SwaraClient` HTTP client for swara.studio endpoints
- expose classes and client in python.api package
- document Python API usage in README
- add unit tests for the client

## Testing
- `pytest -q python/api/tests/client_test.py`
- `pytest -q python/api/tests`

------
https://chatgpt.com/codex/tasks/task_e_6862ed37483c832e95abdb31b222773e