### PR TITLE
Add section properties to Piece

### DIFF
--- a/python/api/classes/piece.py
+++ b/python/api/classes/piece.py
@@ -11,6 +11,10 @@ from .chikari import Chikari
 from .group import Group
 from .automation import get_starts, get_ends
 import math
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .section import Section
 
 SecCatType = Dict[str, Union[Dict[str, bool], str]]
 
@@ -324,6 +328,34 @@ class Piece:
         for phrases in self.phraseGrid:
             for p in phrases:
                 p.raga = self.raga
+
+    # ------------------------------------------------------------------
+    @property
+    def sections_grid(self) -> List[List["Section"]]:
+        from .section import Section
+        grid: List[List["Section"]] = []
+        for i, starts in enumerate(self.sectionStartsGrid):
+            sections: List["Section"] = []
+            for j, s in enumerate(starts):
+                if j == len(starts) - 1:
+                    slice_phrases = self.phraseGrid[i][s:]
+                else:
+                    slice_phrases = self.phraseGrid[i][s:starts[j + 1]]
+                sections.append(
+                    Section(
+                        {
+                            "phrases": slice_phrases,
+                            "categorization": self.sectionCatGrid[i][j],
+                            "ad_hoc_categorization": self.adHocSectionCatGrid[i][j],
+                        }
+                    )
+                )
+            grid.append(sections)
+        return grid
+
+    @property
+    def sections(self) -> List["Section"]:
+        return self.sections_grid[0]
 
     def add_meter(self, meter: Meter) -> None:
         for m in self.meters:

--- a/python/api/tests/piece_test.py
+++ b/python/api/tests/piece_test.py
@@ -625,6 +625,9 @@ def test_piece_method_helpers():
 def test_vocal_display_helpers():
     piece, meter = build_vocal_piece()
 
+    assert len(piece.sections) == 2
+    assert len(piece.sections_grid[0]) == 2
+
     vowels = piece.all_display_vowels()
     assert len(vowels) > 0
     assert len(piece.chunked_display_vowels(0, 1)[0]) == len([v for v in vowels if v['time'] < 1])


### PR DESCRIPTION
## Summary
- add `sections_grid` and `sections` properties mirroring TypeScript logic
- test that vocal pieces expose sections correctly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864362bfbc4832e9def63e94ff224db