### PR TITLE
Fix group parsing in Piece.from_json

### DIFF
--- a/python/api/classes/piece.py
+++ b/python/api/classes/piece.py
@@ -853,7 +853,30 @@ class Piece:
         if "phraseGrid" in new_obj:
             pg = []
             for row in new_obj["phraseGrid"]:
-                pg.append([Phrase.from_json(p) for p in row])
+                phrase_row = [Phrase.from_json(p) for p in row]
+                pg.append(phrase_row)
+            # reconstruct groups so they reference existing trajectories
+            for row in pg:
+                for phrase in row:
+                    new_groups: List[List[Group]] = []
+                    for g_list in phrase.groups_grid:
+                        rebuilt: List[Group] = []
+                        for g in g_list:
+                            data = g if isinstance(g, dict) else g.to_json()
+                            trajs = []
+                            for t in data.get("trajectories", []):
+                                traj = t if isinstance(t, Trajectory) else Trajectory.from_json(t)
+                                num = traj.num
+                                if num is None or num >= len(phrase.trajectory_grid[0]):
+                                    continue
+                                real_traj = phrase.trajectory_grid[0][num]
+                                art = real_traj.articulations.get("0.00") or real_traj.articulations.get("0")
+                                if art and art.name == "slide":
+                                    art.name = "pluck"
+                                trajs.append(real_traj)
+                            rebuilt.append(Group({"trajectories": trajs, "id": data.get("id")}))
+                        new_groups.append(rebuilt)
+                    phrase.groups_grid = new_groups
             new_obj["phraseGrid"] = pg
         if "meters" in new_obj:
             new_obj["meters"] = [Meter.from_json(m) for m in new_obj["meters"]]
@@ -867,4 +890,7 @@ class Piece:
             if isinstance(dm, dict) and "$date" in dm:
                 dm = dm["$date"]
             new_obj["dateModified"] = datetime.fromisoformat(str(dm).replace('Z',''))
-        return Piece(new_obj)
+        piece = Piece(new_obj)
+        piece.dur_array_from_phrases()
+        piece.sectionStartsGrid = [list(dict.fromkeys(arr)) for arr in piece.sectionStartsGrid]
+        return piece


### PR DESCRIPTION
## Summary
- reconstruct `groups_grid` when loading a piece from JSON
- adjust trajectories in groups to reference the existing phrase trajectories
- convert slide articulations at start of grouped trajectories to pluck
- recompute durations and deduplicate section start values

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6864362a4200832eb9123b0a3912ef92