### PR TITLE
Add tests for Piece updates and serialization

### DIFF
--- a/python/api/classes/piece.py
+++ b/python/api/classes/piece.py
@@ -867,4 +867,33 @@ class Piece:
             if isinstance(dm, dict) and "$date" in dm:
                 dm = dm["$date"]
             new_obj["dateModified"] = datetime.fromisoformat(str(dm).replace('Z',''))
-        return Piece(new_obj)
+
+        piece = Piece(new_obj)
+
+        # reconnect groups to actual trajectories
+        for phrases in piece.phraseGrid:
+            for phrase in phrases:
+                new_group_grid: List[List[Group]] = []
+                for group_list in phrase.groups_grid:
+                    rebuilt: List[Group] = []
+                    for g in group_list:
+                        if not isinstance(g, Group):
+                            g = Group.from_json(g)
+                        new_trajs: List[Trajectory] = []
+                        for t in g.trajectories:
+                            if t.num is None:
+                                raise Exception("traj.num is undefined")
+                            new_trajs.append(phrase.trajectory_grid[0][t.num])
+                        rebuilt.append(Group({"trajectories": new_trajs, "id": g.id}))
+                    new_group_grid.append(rebuilt)
+                phrase.groups_grid = new_group_grid
+
+                for traj in phrase.trajectories:
+                    art = traj.articulations.get("0.00")
+                    if art and art.name == "slide":
+                        art.name = "pluck"
+                phrase.consolidate_silent_trajs()
+
+        piece.dur_array_from_phrases()
+        piece.sectionStartsGrid = [sorted(set(arr)) for arr in piece.sectionStartsGrid]
+        return piece


### PR DESCRIPTION
## Summary
- add Python tests for duration arrays when modifying meters/instrumentation
- test serialization reconnects groups and fixes slide articulations
- implement group reconnection and slide fix in `Piece.from_json`

## Testing
- `pytest -q python/api/tests/piece_test.py::test_meters_and_instrumentation_update_duration_arrays python/api/tests/piece_test.py::test_piece_serialization_reconnects_groups_and_fixes_slide -vv`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686436271b70832ea8f69f148bd133c6