### PR TITLE
Implement transcriptions API router

### DIFF
--- a/server/apiRoutes.ts
+++ b/server/apiRoutes.ts
@@ -1,0 +1,43 @@
+import express from 'express';
+import { Collection } from 'mongodb';
+
+interface Collections {
+  transcriptions: Collection;
+}
+
+export default function apiRoutes(collections: Collections) {
+  const router = express.Router();
+
+  router.get('/transcriptions', async (req, res) => {
+    const userId = String(req.query.userId);
+    const sortKey = String(req.query.sortKey);
+    const sortDirParam = String(req.query.sortDir);
+    const sortDir = sortDirParam === '1' ? 1 : -1;
+
+    const query = {
+      $or: [
+        { "explicitPermissions.publicView": true },
+        { "explicitPermissions.edit": userId },
+        { "explicitPermissions.view": userId },
+        { userID: userId },
+      ],
+    };
+
+    const sort: Record<string, 1 | -1> = {};
+    sort[sortKey] = sortDir;
+
+    try {
+      const results = await collections.transcriptions
+        .find(query)
+        .collation({ locale: 'en' })
+        .sort(sort)
+        .toArray();
+      res.json(results);
+    } catch (err) {
+      console.error(err);
+      res.status(500).send(err);
+    }
+  });
+
+  return router;
+}

--- a/server/server.ts
+++ b/server/server.ts
@@ -15,6 +15,7 @@ import { DN_Extractor } from './extract';
 import { DN_ExtractorOptions } from '@shared/types';
 import 'dotenv/config';
 import { $push } from 'mongo-dot-notation';
+import apiRoutes from './apiRoutes';
 const app = express();
 async function exists (path: string) {  
   try {
@@ -167,7 +168,9 @@ const runServer = async () => {
 	const users = db.collection('users');
 	const phonemes = db.collection('phonemes');
 	const collections = db.collection('collections');
-	const gharanas = db.collection('gharanas');
+        const gharanas = db.collection('gharanas');
+
+        app.use('/api', apiRoutes({ transcriptions }));
 	  
 	app.post('/insertNewTranscription', async (req, res) => {
 	  // creates new transcription entry in transcriptions collection


### PR DESCRIPTION
## Summary
- add `apiRoutes.ts` with new `/api/transcriptions` GET route
- mount the router in the server

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6865a704af88832eb46ace9591121eba