### PR TITLE
Fix Python package config layout

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,5 +12,8 @@ dependencies = ["requests", "pymongo", "google-auth-oauthlib"]
 test = ["pytest", "responses"]
 
 [tool.setuptools.packages.find]
-where = ["."]
+where = ["python"]
 include = ["idtap_api*"]
+
+[tool.setuptools.package-dir]
+"" = "python"

--- a/python/idtap_api/client.py
+++ b/python/idtap_api/client.py
@@ -102,7 +102,7 @@ class SwaraClient:
     def get_audio_db_entry(self, _id: str) -> Any:
         return self._post_json("getAudioDBEntry", {"_id": _id})
 
-    def save_piece(self, piece: Dict[str, Any])> Any:
+    def save_piece(self, piece: Dict[str, Any]) -> Any:
         return self._post_json("updateTranscription", piece)
 
     def get_all_pieces(

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,8 @@ from setuptools import setup, find_packages
 setup(
     name="idtap_api",
     version="0.1.0",
-    packages=find_packages(),  # will include the idtap_api/ package
+    packages=find_packages(where="python", include=["idtap_api*"]),
+    package_dir={"": "python"},
     install_requires=[
         "requests",
         "pymongo",


### PR DESCRIPTION
## Summary
- move packaging config to repository root
- update setup.py/pyproject.toml to use `python` source path
- fix typo preventing import in `client.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -e .`
- `python - <<'EOF'
import idtap_api
print('imported', idtap_api.__name__)
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6865bb25c5e4832e84e5ff609585ba73