### PR TITLE
Rename get_all_pieces API call

### DIFF
--- a/python/api_testing/api_test.py
+++ b/python/api_testing/api_test.py
@@ -1,5 +1,5 @@
 from idtap_api.client import SwaraClient
 
 s = SwaraClient()
-s.get_all_pieces()
+s.get_viewable_transcriptions()
 

--- a/python/idtap_api/client.py
+++ b/python/idtap_api/client.py
@@ -105,21 +105,33 @@ class SwaraClient:
     def save_piece(self, piece: Dict[str, Any]) -> Any:
         return self._post_json("updateTranscription", piece)
 
-    def get_all_pieces(
+    def get_viewable_transcriptions(
         self,
         sort_key: str = "title",
         sort_dir: str | int = 1,
         new_permissions: Optional[bool] = None,
     ) -> Any:
+        """Return transcriptions viewable by the user."""
         params = {
-            "userID": self.user_id,
+            "userId": self.user_id,
             "sortKey": sort_key,
             "sortDir": sort_dir,
             "newPermissions": new_permissions,
         }
         # remove None values
         params = {k: str(v) for k, v in params.items() if v is not None}
-        return self._get("getAllTranscriptions", params=params)
+        return self._get("api/transcriptions", params=params)
+
+    # Backwards compatibility alias
+    def get_all_pieces(
+        self,
+        sort_key: str = "title",
+        sort_dir: str | int = 1,
+        new_permissions: Optional[bool] = None,
+    ) -> Any:
+        return self.get_viewable_transcriptions(
+            sort_key=sort_key, sort_dir=sort_dir, new_permissions=new_permissions
+        )
 
     def update_visibility(
         self,


### PR DESCRIPTION
## Summary
- rename `get_all_pieces` to `get_viewable_transcriptions`
- call the `/api/transcriptions` endpoint
- update internal test script

## Testing
- `pip install pytest responses --break-system-packages`
- `pytest -vv python/idtap_api/tests/client_test.py` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6865ce48b288832ea867c49ced0c76b4