### PR TITLE
Improve login flow in client

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ client = SwaraClient()
 piece_json = client.get_piece("abc123")
 ```
 
+When ``SwaraClient`` is first instantiated, it performs a Google login and
+posts the returned profile to the ``/userLoginGoogle`` endpoint. The response
+contains the user's ``_id`` which is stored locally alongside the OAuth token.
+This identifier is required for filtering operations such as
+``get_viewable_transcriptions()``.
+
 Unit tests can be run with `pytest`:
 
 ```bash

--- a/python/idtap_api/client.py
+++ b/python/idtap_api/client.py
@@ -42,9 +42,9 @@ class SwaraClient:
                 
     @property
     def user_id(self) -> Optional[str]:
-        """Return the user ID if available, otherwise None."""
+        """Return the user ID if available, otherwise ``None``."""
         if self.user:
-            return self.user.get("sub")
+            return self.user.get("_id") or self.user.get("sub")
         return None
 
     # ---- auth utilities ----

--- a/python/idtap_api/tests/auth_test.py
+++ b/python/idtap_api/tests/auth_test.py
@@ -38,8 +38,50 @@ def test_auto_login(monkeypatch, tmp_path):
         Path(token_path).write_text(json.dumps({"token": "zzz", "profile": {"_id": "u9"}}))
         return {"_id": "u9"}
 
-    monkeypatch.setattr('python.api.client.login_google', fake_login_google)
+    monkeypatch.setattr('python.idtap_api.client.login_google', fake_login_google)
     token_path = tmp_path / 'token.json'
     client = SwaraClient(token_path=token_path)
     assert calls
     assert client.token == 'zzz'
+
+
+@responses.activate
+def test_login_google_registers(monkeypatch, tmp_path):
+    class FakeFlow:
+        credentials = object()
+
+        def fetch_token(self, code=None):
+            pass
+
+    monkeypatch.setattr(
+        'python.idtap_api.auth.InstalledAppFlow.from_client_config',
+        lambda config, scopes=None: FakeFlow(),
+    )
+    monkeypatch.setattr(
+        'python.idtap_api.auth._run_flow_get_code',
+        lambda flow, host='localhost', port=8080: 'code',
+    )
+
+    class FakeSession:
+        def __init__(self, creds):
+            pass
+
+        def get(self, url):
+            class Resp:
+                def json(self):
+                    return {'sub': 's1', 'name': 'Alice'}
+
+            return Resp()
+
+    monkeypatch.setattr('python.idtap_api.auth.AuthorizedSession', FakeSession)
+
+    responses.post(BASE + 'userLoginGoogle', json={'value': {'_id': 'u1', 'sub': 's1'}}, status=200)
+
+    from python.idtap_api import auth as auth_mod
+
+    profile = auth_mod.login_google(client_secrets={}, base_url=BASE, token_path=tmp_path / 'token.json')
+
+    assert profile['_id'] == 'u1'
+    saved = json.loads((tmp_path / 'token.json').read_text())
+    assert saved['profile']['_id'] == 'u1'
+

--- a/python/idtap_api/tests/client_test.py
+++ b/python/idtap_api/tests/client_test.py
@@ -4,6 +4,7 @@ sys.path.insert(0, os.path.abspath('.'))
 
 import responses
 import pytest
+import json
 
 from python.idtap_api.client import SwaraClient
 
@@ -32,3 +33,20 @@ def test_save_piece():
     responses.post(endpoint, json={'ok': 1}, status=200)
     result = client.save_piece({'_id': '1'})
     assert result == {'ok': 1}
+
+
+@responses.activate
+def test_user_id_prefers_id(tmp_path):
+    token_path = tmp_path / 'token.json'
+    token_path.write_text(json.dumps({'token': 'abc', 'profile': {'_id': 'u1', 'sub': 's1'}}))
+    client = SwaraClient(token_path=token_path, auto_login=False)
+    assert client.user_id == 'u1'
+
+
+@responses.activate
+def test_user_id_fallback_sub(tmp_path):
+    token_path = tmp_path / 'token.json'
+    token_path.write_text(json.dumps({'token': 'abc', 'profile': {'sub': 's1'}}))
+    client = SwaraClient(token_path=token_path, auto_login=False)
+    assert client.user_id == 's1'
+


### PR DESCRIPTION
## Summary
- send Google profile to `/userLoginGoogle` when logging in
- store the returned user document containing `_id`
- read `_id` in SwaraClient when available
- document Google login requirement
- add tests for new login behaviour and user_id property

## Testing
- `python3 -m pip install --break-system-packages -e .[test]`
- `pytest python/idtap_api/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_6865de735fac832ea75b50b14aa52dc2