### PR TITLE
feat: add dotted line playback animation mode

### DIFF
--- a/shared/enums.ts
+++ b/shared/enums.ts
@@ -49,6 +49,7 @@ enum PlayheadAnimations {
   Animated = 'Animated',
   Block = 'Block',
   None = 'None',
+  DottedLine = 'DottedLine',
 }
 
 enum ScaleSystem {

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -940,6 +940,15 @@ type DisplaySettings = {
   }
 }
 
+interface DottedLine {
+  id: string;
+  creationTime: number;
+  position: number;
+  opacity: number;
+  createdAt: number;
+  pausedAt?: number;
+}
+
 interface LoopSourceNode extends AudioBufferSourceNode {
   playing?: boolean;
 }
@@ -1256,6 +1265,7 @@ export type {
   LabelEditorOptions,
   TooltipData,
   DisplaySettings,
+  DottedLine,
   BolDisplayType,
   LoopSourceNode,
   ChikariNodeType,


### PR DESCRIPTION
## Summary

- Add new "DottedLine" playback animation mode to the editor
- Black dotted lines appear every 0.5 seconds at the current playhead position
- Lines fade from opacity 1.0 to 0.0 over 0.5 seconds for smooth animation
- Seamless integration with existing playback controls and animation modes

## Features

- **Visual Animation**: Black dotted vertical lines with 3px dash pattern
- **Timing**: New line every 0.5 seconds, fade duration of 0.5 seconds
- **Performance**: Limited to 20 concurrent lines with efficient cleanup
- **Loop Support**: Lines clear automatically when loops restart
- **Time Stretching**: Works correctly with region-based time stretching
- **UI Integration**: Appears in existing "Playback Animation" dropdown

## Behavior

- **When Playing**: Shows animated dotted lines, hides normal playhead
- **When Paused**: Shows normal playhead at exact current time, all dotted lines cleared
- **Double-click**: Works normally when paused for precise time navigation
- **Transitions**: Smooth switching between animation modes

## Test Plan

- [x] Verify dotted lines appear every 0.5 seconds during playback
- [x] Test smooth fade animation from opacity 1.0 to 0.0
- [x] Confirm normal playhead appears at correct time when paused
- [x] Test double-click navigation when paused
- [x] Verify loop functionality clears lines on restart
- [x] Test time stretching compatibility
- [x] Verify UI dropdown includes new option
- [x] Test performance with extended playback sessions

🤖 Generated with [Claude Code](https://claude.ai/code)