### PR TITLE
feat: add user-specific override for dotted line animation

### DIFF
--- a/src/comps/editor/audioPlayer/SpectrogramControls.vue
+++ b/src/comps/editor/audioPlayer/SpectrogramControls.vue
@@ -1139,6 +1139,9 @@ export default defineComponent({
       if (s.playheadAnimationStyle !== undefined) {
         playheadAnimationProxy.value = s.playheadAnimationStyle;
       }
+      if (store.state.userID === '634d9506a6a3647e543b7641') {
+        playheadAnimationProxy.value = PlayheadAnimations.DottedLine;
+      }
       if (s.highlightTrajs !== undefined) {
         highlightTrajsProxy.value = s.highlightTrajs;
       }


### PR DESCRIPTION
## Summary
- Add hardcoded override for specific user ID to automatically use dotted line animation
- Override is applied after settings load to ensure it persists across sessions
- Completes the dotted line animation feature implementation

## Test plan
- [ ] Verify the specific user automatically gets dotted line animation on page load
- [ ] Verify other users continue to get the default animated playhead
- [ ] Verify the override persists after changing other settings

🤖 Generated with [Claude Code](https://claude.ai/code)